### PR TITLE
vkmirror: mirror RTX Remix depth (R32_SFLOAT colour image, VkFormat 100)

### DIFF
--- a/src/vkmirror.inc
+++ b/src/vkmirror.inc
@@ -188,6 +188,11 @@ static const uint32_t kVkmAspectStencil = 4;
 // starts recording it.
 static uint32_t VkmDepthAspect(uint32_t vkfmt)
 {
+    // RTX Remix hands NGX its depth as a COLOUR image in R32_SFLOAT (VkFormat 100,
+    // aspect COLOR). A barrier naming DEPTH on a colour image is invalid, so the
+    // barrier for that slot must name COLOR instead.
+    if (vkfmt == kVkFmtR32Sfloat)
+        return kSVkAspectColor;
     return (vkfmt == kVkFmtD16UnormS8Uint || vkfmt == kVkFmtD24UnormS8Uint ||
             vkfmt == kVkFmtD32SfloatS8Uint)
                ? (kSVkAspectDepth | kVkmAspectStencil)
@@ -1304,8 +1309,12 @@ static void VkMirrorFrame(void *cmd_raw, const NVSDK_NGX_Parameter *gp)
     // the 32-bit staging texture are both wrong for; that is an R16_UNORM slot
     // and a different change, and no measured title needs it.
     const bool depth_packed = res[SLOT_DEPTH].fmt == kVkFmtD24UnormS8Uint;
+    // VkFormat 100 (R32_SFLOAT): RTX Remix's depth is a colour image whose bytes are
+    // already the R32_FLOAT the feature reads -- same shared-texture path as 126/130,
+    // no unpack. Its copy/barrier take the COLOUR aspect (see VkmDepthAspect and the
+    // copy below), everything else is identical to the D32_SFLOAT case.
     if (res[SLOT_DEPTH].fmt != kVkFmtD32Sfloat && res[SLOT_DEPTH].fmt != kVkFmtD32SfloatS8Uint &&
-        !depth_packed)
+        res[SLOT_DEPTH].fmt != kVkFmtR32Sfloat && !depth_packed)
     {
         char msg[224];
         _snprintf_s(msg, sizeof(msg), _TRUNCATE,
@@ -1493,7 +1502,10 @@ static void VkMirrorFrame(void *cmd_raw, const NVSDK_NGX_Parameter *gp)
         const UINT dh = res[SLOT_DEPTH].h < rh ? res[SLOT_DEPTH].h : rh;
 
         SVkBufferImageCopy c = {};
-        c.imageSubresource.aspectMask = kSVkAspectDepth;
+        // R32_SFLOAT depth (Remix) is a colour image: copy its COLOUR aspect. True
+        // depth formats copy their DEPTH aspect (depth only, even when combined).
+        c.imageSubresource.aspectMask =
+            (res[SLOT_DEPTH].fmt == kVkFmtR32Sfloat) ? kSVkAspectColor : kSVkAspectDepth;
         c.imageSubresource.layerCount = 1;
         c.imageExtent.width  = dw;
         c.imageExtent.height = dh;


### PR DESCRIPTION
## Problem

RTX Remix hands NGX its depth as a **colour image in `R32_SFLOAT`** (`VkFormat 100`, aspect `COLOR`). The mirror only accepts true depth formats (`D32_SFLOAT` 126, `D24_UNORM_S8_UINT` 129, `D32_SFLOAT_S8_UINT` 130) and refuses with `the mirror does nothing` — so the DLSS 5 Neural Rendering add-on never receives a depth texture and no NR pass runs under Remix.

## Fix

14 lines in `src/vkmirror.inc`:

- `VkmDepthAspect`: `VkFormat 100` barriers with the **COLOR** aspect (a DEPTH barrier on a colour image is invalid);
- depth-slot acceptance: `R32_SFLOAT` joins 126/130 — its bytes are already the `R32_FLOAT` the feature reads, same shared-texture path, no unpack;
- `CmdCopyImageToBuffer`: copy the **COLOR** aspect for `R32_SFLOAT`, DEPTH for true depth formats.

## Verification

Built with the repo's own `build.cmd` (MSVC, `/W4 /O2 /MT /std:c++17`) — compiles clean.

Tested in two RTX Remix titles on an RTX 5070 Ti (driver 616.56):

| Game | Remix | Result |
| --- | --- | --- |
| Half-Life 2 RTX | 0.13 | full NR, `feature 18 evaluation succeeded (count=60+)` |
| Painkiller RTX | 0.15 | NR running (`count=60`, `workset pool exhausted: 0`) |

Note: the exposure texture is already handled on current main (the `ExposureTexture` mirror), so no `flags=` workaround is needed with this change on top of it.

https://www.youtube.com/@perseval_BLR =)