### PR TITLE
Build and attest official addon downloads

### DIFF
--- a/.github/workflows/verify-download-checker.yml
+++ b/.github/workflows/verify-download-checker.yml
@@ -1,25 +1,86 @@
-name: Download verifier checks
+name: Build and verify
 
 on:
   push:
     branches: [main]
-    paths: ['tools/**', '.github/**', 'VERIFYING-DOWNLOADS.md']
   pull_request:
-    paths: ['tools/**', '.github/**', 'VERIFYING-DOWNLOADS.md']
+    branches: [main]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  verify:
-    runs-on: windows-latest
-    timeout-minutes: 5
+  build:
+    name: Build and verifier checks
+    runs-on: windows-2025
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.sha }}
           persist-credentials: false
       - name: Windows PowerShell 5.1
         run: powershell.exe -NoProfile -File tools/Test-Verify-Bridge.ps1
       - name: PowerShell 7
         run: pwsh -NoProfile -File tools/Test-Verify-Bridge.ps1
+      - name: Build addon
+        shell: cmd
+        run: call src\build.cmd
+      - name: Record build and checksums
+        shell: pwsh
+        run: |
+          $commit = git rev-parse HEAD
+          if ($LASTEXITCODE -ne 0 -or $commit -cne $env:GITHUB_SHA) {
+            throw 'The checkout does not match the workflow commit.'
+          }
+          New-Item -ItemType Directory -Path dist | Out-Null
+          Copy-Item -LiteralPath src/dlss5-bridge.addon64 -Destination dist/
+          $addon = Get-Item -LiteralPath dist/dlss5-bridge.addon64
+          @(
+            "Repository: $env:GITHUB_REPOSITORY"
+            "Commit: $commit"
+            "Ref: $env:GITHUB_REF"
+            "Workflow run: $env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
+            "File version: $($addon.VersionInfo.FileVersion)"
+            "Bytes: $($addon.Length)"
+          ) | Set-Content -LiteralPath dist/BUILD-INFO.txt -Encoding utf8
+          Get-FileHash -LiteralPath dist/dlss5-bridge.addon64, dist/BUILD-INFO.txt -Algorithm SHA256 |
+            ForEach-Object { "$($_.Hash.ToLowerInvariant())  $([IO.Path]::GetFileName($_.Path))" } |
+            Set-Content -LiteralPath dist/SHA256SUMS.txt -Encoding ascii
+          Get-Content -LiteralPath dist/BUILD-INFO.txt, dist/SHA256SUMS.txt
+      - name: Upload build
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dlss5-bridge-${{ github.sha }}
+          path: dist/*
+          if-no-files-found: error
+          retention-days: 30
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+
+  attest:
+    name: Attest main build
+    needs: build
+    if: >-
+      github.repository == 'NIGos/dlss5-bridge' &&
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download this run's build
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          artifact-ids: ${{ needs.build.outputs.artifact-id }}
+          path: dist
+          merge-multiple: true
+      - name: Attest addon provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-checksums: dist/SHA256SUMS.txt

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.ilk
 *.log
 *.cfg
+/src/dlss5-bridge.addon64

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ proxy for a build that needs it.
 
 ## Install
 
+**Download `dlss5-bridge.addon64` only from [our GitHub releases](https://github.com/NIGos/dlss5-bridge/releases).**
+Bridge has no installer and never asks you to disable antivirus protection or
+add exclusions. ReShade has its own legitimate installer, available separately
+from [reshade.me](https://reshade.me/). [Verify the Bridge file](VERIFYING-DOWNLOADS.md)
+before putting it in the game folder.
+
 Install ReShade for the correct API, then copy `dlss5-bridge.addon64` and the
 neural add-on's files into its add-on search location, normally beside the
 game executable. On first run the Bridge writes `dlss5-bridge.cfg` with defaults

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,31 +5,62 @@ publishing.** After publication, assets and the release tag cannot be replaced.
 Use a new version for a correction; do not delete/recreate an old release to
 retrofit immutability. Existing releases retain their original status.
 
-1. Build from the intended reviewed commit. Run the relevant Gym checks and
-   `powershell -NoProfile -File tools\Test-Verify-Bridge.ps1`. Confirm that the
-   binary version, release tag and intended commit agree. Do not package unrelated
+1. Prepare the release through a pull request. Review the diff and require the
+   build and verification checks to pass before merging. The project has one
+   maintainer; this is a recorded review and CI check, not independent approval.
+   Run the relevant Gym checks for code changes; the hosted build does not test
+   games or GPU behavior. Confirm that the binary version and intended release
+   tag agree.
+2. Use the successful **Build and verify** run for the exact merged commit on
+   `main`, including its **Attest main build** job. Download that run's
+   `dlss5-bridge-COMMIT_SHA` artifact into a clean staging folder. It contains the
+   addon, `SHA256SUMS.txt` and `BUILD-INFO.txt`. Verify the addon using the build
+   provenance command below, supplying the full commit SHA. Check that the run,
+   `BUILD-INFO.txt`, checksum and intended tag all identify the same source and
+   file. Do not substitute a local rebuild or a pull request artifact.
+   The binary is published as `dlss5-bridge.addon64`; do not package unrelated
    addons, NVIDIA model DLLs, installers or files from third-party bundles.
-2. If publisher signing is configured in future, sign and timestamp the final
+3. If publisher signing is configured in future, sign and timestamp the final
    binary, then verify the expected publisher's signature. **Hash after signing.**
    Signing is not currently configured; do not claim that an unsigned build is signed.
-3. Calculate SHA-256 for every final asset. Record the addon hash, exact byte size
-   and intended source commit in the release notes. Prepare `SHA256SUMS.txt` with
-   one line per final downloadable file, excluding the checksum file itself.
-4. Create and push the intended version tag once. Confirm it resolves remotely
+   Signing changes the binary, so the signing workflow must also attest the final
+   signed file; an attestation for the unsigned file will no longer match it.
+4. Record the final addon hash, exact byte size, source commit and successful
+   build-run link in the release notes. Recheck the CI checksum before uploading.
+   If adding any release assets, include their hashes in `SHA256SUMS.txt`, with
+   one line per file excluding the checksum file itself.
+5. Create and push the intended version tag once. Confirm it resolves remotely
    to the intended commit. Create a **draft** release for that existing tag,
    with the correct prerelease/latest settings, notes and every final asset.
    With the CLI, use `gh release create ... --draft --verify-tag --repo github.com/NIGos/dlss5-bridge`.
    Do not publish an empty release and upload its addon afterward.
-5. Before publishing, compare the draft's GitHub asset digests and sizes with the
+6. Before publishing, compare the draft's GitHub asset digests and sizes with the
    local final files. Review its tag/commit and complete asset list. If anything
    differs or is missing, keep the release in draft and correct it.
-6. Publish the reviewed draft. Confirm that GitHub reports it as immutable and
+7. Publish the reviewed draft. Confirm that GitHub reports it as immutable and
    that it has the intended stable/prerelease/latest status. Verify its attestation
    and the local final addon using the commands below. A failed or unavailable
    attestation is not a successful verification; do not announce success while it
    is unresolved.
-7. Update the version-specific SHA-256 reference in `VERIFYING-DOWNLOADS.md` and
+8. Update the version-specific SHA-256 reference in `VERIFYING-DOWNLOADS.md` and
    link the release from the README. Keep the security warning and official URLs.
+
+## Verify the build before publication
+
+With a current GitHub CLI, replace `COMMIT_SHA` with the full commit from the
+successful `main` run and use the downloaded addon's path:
+
+```powershell
+gh attestation verify 'C:\path\dlss5-bridge.addon64' --repo NIGos/dlss5-bridge --hostname github.com --signer-workflow NIGos/dlss5-bridge/.github/workflows/verify-download-checker.yml --source-ref refs/heads/main --source-digest COMMIT_SHA --deny-self-hosted-runners
+```
+
+This verifies the file against this repository's named workflow and exact source
+commit on a GitHub-hosted runner. The build comes from `main`; the release tag
+must point to that same commit. If verification fails, do not publish the file
+as a verified CI build. Rerunning the build can produce a different binary;
+always verify and publish the artifact from the selected successful run.
+
+## Verify the published release
 
 For the actual newly published tag, replace `TAG` and the local path:
 
@@ -48,4 +79,5 @@ and CI results before applying changes; workflow tokens default to read-only,
 and external contributor workflows need approval.
 
 Sources: [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases),
-[release verification](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/verify-release-integrity).
+[release verification](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/verify-release-integrity),
+[build provenance verification](https://cli.github.com/manual/gh_attestation_verify).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -10,7 +10,8 @@ retrofit immutability. Existing releases retain their original status.
    maintainer; this is a recorded review and CI check, not independent approval.
    Run the relevant Gym checks for code changes; the hosted build does not test
    games or GPU behavior. Confirm that the binary version and intended release
-   tag agree.
+   tag agree. Compare the source against the release being replaced: a
+   prerelease may contain fixes on a separate branch that are not yet on `main`.
 2. Use the successful **Build and verify** run for the exact merged commit on
    `main`, including its **Attest main build** job. Download that run's
    `dlss5-bridge-COMMIT_SHA` artifact into a clean staging folder. It contains the
@@ -73,10 +74,13 @@ Use a current GitHub CLI with these commands. Specify the full GitHub host and
 repository, even when running from another checkout. These are native GitHub
 release attestations; no locally generated signing key is required.
 
-Repository controls also prevent force-pushing/deleting `main` and moving or
-deleting `v*` tags. Normal commits and new tags are allowed. Review pull requests
-and CI results before applying changes; workflow tokens default to read-only,
-and external contributor workflows need approval.
+Repository controls require a pull request and the successful **Build and
+verifier checks** check from GitHub Actions before merging into `main`. The
+branch must be up to date and review conversations resolved. Required human
+approvals are zero, so the sole maintainer can merge their own checked pull
+request. There are no bypass actors. Force-pushing/deleting `main` and moving
+or deleting `v*` tags are also blocked; new tags remain allowed. Workflow tokens
+default to read-only, and external contributor workflows need approval.
 
 Sources: [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases),
 [release verification](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/verify-release-integrity),

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,11 @@ Downloads are published on its [Releases page](https://github.com/NIGos/dlss5-br
 The domain `dlss5bridge.com` is not owned, operated or endorsed by this project.
 See [#30](https://github.com/NIGos/dlss5-bridge/issues/30) for the reported incident.
 
+Bridge is distributed as **`dlss5-bridge.addon64`**, without a Bridge installer.
+It never asks users to disable antivirus protection or add exclusions. ReShade
+has its own legitimate installer at [reshade.me](https://reshade.me/), separate
+from the Bridge download.
+
 Follow [Verify a Bridge download](VERIFYING-DOWNLOADS.md) before loading a file.
 A filename, version number, copied project page or in-game badge does not prove
 authenticity. A hash match checks the selected file, not other files in a package.
@@ -36,6 +41,10 @@ immutable. Check the release's actual status instead of assuming from its versio
 
 The attestation identifies what GitHub published for this repository and tag.
 It is not an independent audit of the source or proof that a binary is harmless.
+Build provenance is a separate attestation that links a file to the source
+commit and GitHub Actions workflow that produced it. Neither kind is an
+Authenticode publisher signature. Follow the verification instructions for the
+specific release; older releases do not gain these attestations retroactively.
 Current legacy binaries are unsigned with Authenticode. We do not use a
 self-signed certificate or an internal integrity badge as a substitute for
 publisher authentication.

--- a/VERIFYING-DOWNLOADS.md
+++ b/VERIFYING-DOWNLOADS.md
@@ -5,6 +5,10 @@ as the source for both the addon and these instructions. `dlss5bridge.com` is
 not operated or endorsed by this project. A matching filename or version
 number does not establish where a file came from.
 
+The Bridge download is **`dlss5-bridge.addon64`**. We do not distribute a Bridge
+installer or ask you to disable antivirus protection or add exclusions.
+ReShade's installer is a separate download from [reshade.me](https://reshade.me/).
+
 **Check before copying the addon into the game folder or starting the game.**
 Verification does not require loading the addon, running an installer, or
 administrator privileges.
@@ -57,7 +61,7 @@ above; weakening execution policy is not required for verification.
   GitHub rate limits, missing releases and missing digests also fail verification;
   none is treated as a successful check.
 
-## What this protects
+## Verify an immutable release
 
 For a **new immutable release**, GitHub also provides a cryptographically
 verifiable release attestation. With a current GitHub CLI, replace `TAG` and
@@ -73,6 +77,27 @@ releases in the table above, or to GitHub's automatically generated source archi
 Immutability was enabled on 9 September 2026 for future releases; it does not
 retroactively authenticate older releases. The PowerShell checker remains a
 SHA-256/size comparison, and does not claim to verify an attestation.
+
+## Verify where a CI build came from
+
+For releases that provide GitHub Actions build provenance, the release notes
+identify the source commit and build run. With a current GitHub CLI, replace
+`COMMIT_SHA` with that full commit SHA and supply the downloaded addon's path:
+
+```powershell
+gh attestation verify 'C:\path\dlss5-bridge.addon64' --repo NIGos/dlss5-bridge --hostname github.com --signer-workflow NIGos/dlss5-bridge/.github/workflows/verify-download-checker.yml --source-ref refs/heads/main --source-digest COMMIT_SHA --deny-self-hosted-runners
+```
+
+This checks that the file was attested by the named build workflow for that
+source commit on a GitHub-hosted runner. Release verification above answers a
+different question: whether the file matches what was published for a specific
+immutable release. Use both checks for a release that provides both attestations.
+These checks read the file without loading it. A missing or failed attestation
+does not count as verified; older releases were not built with this workflow.
+See the [GitHub CLI documentation](https://cli.github.com/manual/gh_attestation_verify)
+for the verification options.
+
+## What this protects
 
 The trusted reference is this GitHub repository and its HTTPS API. A hash
 copied from the same untrusted download site does not establish authenticity.

--- a/src/build.cmd
+++ b/src/build.cmd
@@ -2,12 +2,24 @@
 rem dlss5-bridge -- build. The exact line the README quotes; kept here because it
 rem has been retyped by hand once too often and lost a flag each time.
 setlocal
-set VCVARS=C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\Build\vcvars64.bat
+rem Honor an explicit toolchain, otherwise use the latest installed C++ tools.
+if defined VCVARS goto toolchain_found
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+  echo build.cmd: Visual Studio Installer vswhere.exe was not found; set VCVARS to vcvars64.bat
+  exit /b 1
+)
+for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VCVARS=%%I\VC\Auxiliary\Build\vcvars64.bat"
+:toolchain_found
 if not exist "%VCVARS%" (
   echo build.cmd: no vcvars64.bat at "%VCVARS%"
   exit /b 1
 )
 call "%VCVARS%" >nul 2>&1
+if errorlevel 1 (
+  echo build.cmd: failed to initialize "%VCVARS%"
+  exit /b 1
+)
 cd /d "%~dp0"
 
 rc /nologo version.rc


### PR DESCRIPTION
Official addon downloads currently have no verifiable link to the build that produced them. This adds a Windows CI build and GitHub provenance tied to the exact source commit. Only successful builds of this repository's main branch receive attestations; pull requests run with read-only permissions.

The same check runs the download-verifier tests on Windows PowerShell 5.1 and PowerShell 7. Build artifacts include the addon, checksums and source/run details. The publishing guide now uses those exact artifacts and a complete draft before immutable publication. Download guidance also clarifies that Bridge has no installer and does not request antivirus exclusions.

Validation: both local MSVC discovery paths build without warnings, an invalid toolchain fails, all 15 verifier cases pass in both PowerShell versions, and actionlint passes. Hosted compilation runs on this PR; provenance is checked after the first successful main build. No rendering code changes.
