### PR TITLE
Document protected releases and verification status

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,7 +3,16 @@
 Release immutability is enabled. **Upload every final asset to a draft before
 publishing.** After publication, assets and the release tag cannot be replaced.
 Use a new version for a correction; do not delete/recreate an old release to
-retrofit immutability. Existing releases retain their original status.
+retrofit immutability.
+
+Check an existing release's actual `immutable` status before and after editing
+it. In this repository, updating the published notes on 9 September 2026
+finalized immutability for **v1.4.12, v1.4.13-pre1, v1.4.13-pre2, v1.4.13-pre3
+and v1.3.0**, without replacing their tags or binaries. Their release attestations
+were verified. Do not assume an older release will remain mutable after an edit:
+confirm its tag and complete asset list first. This locks the existing files;
+it does not create provenance for their historical builds. New releases must
+still be complete drafts before publication.
 
 1. Prepare the release through a pull request. Review the diff and require the
    build and verification checks to pass before merging. The project has one
@@ -63,7 +72,7 @@ always verify and publish the artifact from the selected successful run.
 
 ## Verify the published release
 
-For the actual newly published tag, replace `TAG` and the local path:
+For the intended immutable release, replace `TAG` and the local path:
 
 ```powershell
 gh release verify TAG --repo github.com/NIGos/dlss5-bridge

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,20 +34,22 @@ use a trusted device to secure affected accounts and seek incident-response help
 
 ## Release integrity
 
-Release immutability was enabled on **9 September 2026**. It applies to future
-releases: their published assets and associated tags are locked, and GitHub
-generates a release attestation. Earlier releases are not retroactively made
-immutable. Check the release's actual status instead of assuming from its version.
+Release immutability was enabled on **9 September 2026**. The existing releases
+**v1.4.12, v1.4.13-pre1, v1.4.13-pre2, v1.4.13-pre3 and v1.3.0** were also made
+immutable that day when their notes were updated with a download warning.
+Their original tags, publication dates and addon files were preserved, and their
+release attestations were verified. Their assets and associated tags are now
+locked. Check any other release's actual status instead of assuming from its version.
 
 The attestation identifies what GitHub published for this repository and tag.
 It is not an independent audit of the source or proof that a binary is harmless.
 Build provenance is a separate attestation that links a file to the source
-commit and GitHub Actions workflow that produced it. Neither kind is an
-Authenticode publisher signature. Follow the verification instructions for the
-specific release; older releases do not gain these attestations retroactively.
-Current legacy binaries are unsigned with Authenticode. We do not use a
-self-signed certificate or an internal integrity badge as a substitute for
-publisher authentication.
+commit and GitHub Actions workflow that produced it. The five releases above
+have release attestations, but **no CI build provenance or Authenticode publisher
+signature**. Locking their existing files does not establish how they were
+originally built. Follow the verification instructions for the specific release.
+We do not use a self-signed certificate or an internal integrity badge as a
+substitute for publisher authentication.
 
 Maintainers must follow [the release procedure](RELEASING.md). Protect the
 maintainer's GitHub account with strong two-factor authentication or a passkey,

--- a/VERIFYING-DOWNLOADS.md
+++ b/VERIFYING-DOWNLOADS.md
@@ -63,22 +63,30 @@ above; weakening execution policy is not required for verification.
 
 ## Verify an immutable release
 
-For a **new immutable release**, GitHub also provides a cryptographically
-verifiable release attestation. With a current GitHub CLI, replace `TAG` and
-the file path with the actual release and your local addon:
+**All five releases in the table above are now immutable and have verified
+release attestations.** Their notes were updated on 9 September 2026, which
+finalized immutability for these existing releases. Their original tags,
+publication dates and addon hashes were preserved.
+
+With a current GitHub CLI, replace `TAG` and the file path with the intended
+release and your local addon:
 
 ```powershell
 gh release verify TAG --repo github.com/NIGos/dlss5-bridge
 gh release verify-asset TAG 'C:\path\dlss5-bridge.addon64' --repo github.com/NIGos/dlss5-bridge
 ```
 
-Both commands must succeed. These commands do not apply to the older mutable
-releases in the table above, or to GitHub's automatically generated source archives.
-Immutability was enabled on 9 September 2026 for future releases; it does not
-retroactively authenticate older releases. The PowerShell checker remains a
-SHA-256/size comparison, and does not claim to verify an attestation.
+Both commands must succeed. For any release outside the table, check its actual
+immutability status; these commands do not apply to mutable releases or GitHub's
+automatically generated source archives. The attestation authenticates the files
+now locked to that release, without proving how the older binaries were built.
+The PowerShell checker remains a SHA-256/size comparison and does not verify an
+attestation.
 
 ## Verify where a CI build came from
+
+The five releases above **do not have CI build provenance**. Their release
+attestations do not add it retroactively.
 
 For releases that provide GitHub Actions build provenance, the release notes
 identify the source commit and build run. With a current GitHub CLI, replace


### PR DESCRIPTION
Five existing releases are now immutable after their download warnings were updated: v1.4.12, v1.4.13-pre1, pre2, pre3 and v1.3.0. Update the verification guide to reflect their actual status and explain that release attestations do not give these older binaries CI build provenance or an Authenticode signature.

Verified all five release attestations and their downloaded addon files with GitHub CLI. Their original asset IDs, hashes, sizes, tags and publication dates are unchanged. No binaries or rendering code changed.
