### PR TITLE
Prepare cumulative v1.4.13-pre4 test release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # DLSS 5 Bridge
 
-**v1.4.13-pre2 â€” Vulkan Frame Generation test for [Endfield (#27)](https://github.com/NIGos/dlss5-bridge/issues/27).**
-The Bridge now leaves the Frame Generation DLL untouched. This fixes a reproduced
-Vulkan FG initialization failure in ngxGym, including with FG 310.9 and neural
-rendering active. Actual FG/MFG output in Endfield still needs confirmation.
+**v1.4.13-pre3 — Vulkan mirror polling test for [Endfield (#27)](https://github.com/NIGos/dlss5-bridge/issues/27).**
+The Vulkan mirror and synthetic OFA workers now use a high-resolution timer
+between event checks. Repeated ngxGym tests showed less polling CPU time and
+shorter waits; the effect on Endfield's reported FPS loss still needs testing.
+The original polling remains the fallback if the timer is unavailable or fails.
+This build retains pre2's FG initialization fix, confirmed by the Endfield reporter.
 This prerelease also retains pre1's D3D11 partial-output copy-back fix for
 [BG3 split screen (#12)](https://github.com/NIGos/dlss5-bridge/issues/12);
 complete BG3 split-screen neural rendering and temporal quality remain unverified.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # DLSS 5 Bridge
 
+**v1.4.13-pre1 — targeted test for [BG3 split screen (#12)](https://github.com/NIGos/dlss5-bridge/issues/12).**
+Based on v1.4.12, this build fixes D3D11 partial-output copy-back at nonzero
+output origins: processing one atlas region must not overwrite its neighbour.
+The spatial defect is reproduced in ngxGym; complete BG3 split-screen neural
+rendering and temporal quality are not yet verified. This is a prerelease.
+Before replacing the add-on, back up its DLL and configuration. Set the first
+line of `dlss5-bridge.cfg` to `# dlss5-bridge keep` to preserve your settings
+across the version change. Install only one bridge DLL at a time.
+
 **DLSS 5 Neural Rendering for DirectX 11 games, Vulkan games, and, as an
 option, games that have no DLSS at all, through NVIDIA Optical Flow, at lower
 quality.**

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ development:
 
 Releases and their notes: [github.com/NIGos/dlss5-bridge/releases](https://github.com/NIGos/dlss5-bridge/releases).
 
-**Release status (7 September 2026).** [v1.4.12](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.12)
-is the stable release and the code on `main`.
-[v1.4.13-pre2](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre2)
-adds a Vulkan Frame Generation initialization fix and retains pre1's D3D11
-partial-output fix for BG3 split screen. Both defects are reproduced in
-[ngxGym](https://github.com/NIGos/ngxGym); actual FG/MFG output in Endfield and
-complete BG3 split-screen rendering still need in-game confirmation.
+**Release status (9 September 2026).** [v1.4.12](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.12)
+remains the stable release. `main` contains the cumulative 1.4.13 prerelease
+changes and the [D3D11 depth/MV conversion fix](https://github.com/NIGos/dlss5-bridge/pull/34).
+The latest published test build is
+[v1.4.13-pre3](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre3).
+BG3 split-screen rendering and coexistence with its Vulkan FG mod remain open
+issues. The Endfield reporter found no FPS improvement from pre3.
 
 Some neural add-ons support additional graphics APIs directly. Whether you need
 this bridge depends on the add-on build and the game. See the compatibility
@@ -226,8 +226,10 @@ not a claim that all current models need it.
 Additional reports, scoped to the tested setups:
 
 - [Endfield Vulkan, v1.4.12](https://github.com/NIGos/dlss5-bridge/issues/17#issuecomment-5553000888):
-  the reporter confirmed correct neural rendering. FG/MFG is a separate
-  [#27](https://github.com/NIGos/dlss5-bridge/issues/27) issue under test in pre2.
+  the reporter confirmed correct neural rendering. In
+  [#27](https://github.com/NIGos/dlss5-bridge/issues/27), pre2 restored FG in the
+  reported setup; the mirror slowdown remains open, with no FPS improvement
+  reported from pre3.
 - [BG3 D3D11 with neural-upstream v0.3.0](https://github.com/NIGos/dlss5-bridge/issues/26):
   reported working on RTX 4090 / driver 616.64. Not locally verified.
 - [Linux/Proton, D3D11 substitute](https://github.com/NIGos/dlss5-bridge/issues/22):
@@ -274,10 +276,12 @@ driver or another add-on can still crash the game or produce an incorrect image.
 - **HDR on the substitute path.** The input may already include the game's
   tone mapping and UI. With neural rendering this can alter colors across the
   whole view. A general solution that preserves the game's presentation is
-  still under investigation; no universal HDR fix is in the stable or pre2 build.
-- **FG and split screen.** v1.4.13-pre2 fixes reproduced FG initialization and
-  D3D11 partial-output defects. Endfield's generated frames and BG3's complete
-  split-screen neural output still need in-game confirmation.
+  still under investigation; no universal HDR fix is included.
+- **FG and split screen.** The 1.4.13 prereleases fix reproduced Vulkan FG
+  initialization and D3D11 partial-output defects. BG3's complete split-screen
+  neural output remains unresolved ([#12](https://github.com/NIGos/dlss5-bridge/issues/12)).
+  A separate hook conflict with BG3's Vulkan FG mod also remains open
+  ([#28](https://github.com/NIGos/dlss5-bridge/issues/28)).
 - **Substitute before the game's DLSS.** This order has caused faults in tested
   neural add-on builds when native DLSS first appears. Prefer the native DLSS
   route and leave the substitute off in games that provide it.
@@ -301,7 +305,7 @@ driver or another add-on can still crash the game or produce an incorrect image.
   substitute both follow it.
 - **Partial D3D11 output.** Stable v1.4.12 copies a partial result at 0,0;
   this can overwrite the wrong region when the game supplies a nonzero output
-  origin. Pre1 and pre2 preserve the declared origin. The original evaluate
+  origin. The 1.4.13 prereleases preserve the declared origin. The original evaluate
   is retained on partial-output frames to preserve the surrounding texture.
 - Verbose logging is always on.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # DLSS 5 Bridge
 
-**v1.4.13-pre1 — targeted test for [BG3 split screen (#12)](https://github.com/NIGos/dlss5-bridge/issues/12).**
-Based on v1.4.12, this build fixes D3D11 partial-output copy-back at nonzero
-output origins: processing one atlas region must not overwrite its neighbour.
-The spatial defect is reproduced in ngxGym; complete BG3 split-screen neural
-rendering and temporal quality are not yet verified. This is a prerelease.
+**v1.4.13-pre2 — Vulkan Frame Generation test for [Endfield (#27)](https://github.com/NIGos/dlss5-bridge/issues/27).**
+The Bridge now leaves the Frame Generation DLL untouched. This fixes a reproduced
+Vulkan FG initialization failure in ngxGym, including with FG 310.9 and neural
+rendering active. Actual FG/MFG output in Endfield still needs confirmation.
+This prerelease also retains pre1's D3D11 partial-output copy-back fix for
+[BG3 split screen (#12)](https://github.com/NIGos/dlss5-bridge/issues/12);
+complete BG3 split-screen neural rendering and temporal quality remain unverified.
 Before replacing the add-on, back up its DLL and configuration. Set the first
 line of `dlss5-bridge.cfg` to `# dlss5-bridge keep` to preserve your settings
 across the version change. Install only one bridge DLL at a time.

--- a/src/bridge.inc
+++ b/src/bridge.inc
@@ -4411,6 +4411,17 @@ static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter
     // was what left House Party (#8, pull request #9) with no neural rendering
     // in any gameplay scene: its allocations are padded for dynamic resolution,
     // 5120x2048 for a 5120x1440 display, so every frame was "partial".
+    unsigned int output_x = 0, output_y = 0;
+    gp->Get("DLSS.Output.Subrect.Base.X", &output_x);
+    gp->Get("DLSS.Output.Subrect.Base.Y", &output_y);
+    if (output_x > d[SLOT_OUTPUT].Width || output_y > d[SLOT_OUTPUT].Height ||
+        gow > d[SLOT_OUTPUT].Width - output_x || goh > d[SLOT_OUTPUT].Height - output_y)
+    {
+        BridgeDisable("the output region exceeds its texture; no output is copied back");
+        for (int i = 0; i < SLOT_COUNT; ++i) g[i]->Release();
+        dev11->Release();
+        return;
+    }
     const bool partial = (gow != d[SLOT_OUTPUT].Width) || (goh != d[SLOT_OUTPUT].Height);
     g_bridge.partial_output = partial;
     // Only for the game's own contract. The substitute's block is written by
@@ -4429,10 +4440,10 @@ static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter
     {
         g_bridge.partial_reported = true;
         Log("[bridge] the game asks for a %ux%u result inside a %ux%u texture. The "
-            "region at 0,0 is written and the rest of the texture left as it is, "
+            "region at %u,%u is written and the rest of the texture left as it is, "
             "which is what the game's own DLSS does with the same block. The game's "
             "own evaluate is not skipped on these frames.",
-            gow, goh, d[SLOT_OUTPUT].Width, d[SLOT_OUTPUT].Height);
+            gow, goh, d[SLOT_OUTPUT].Width, d[SLOT_OUTPUT].Height, output_x, output_y);
     }
 
     bool shape_changed = (gw != g_bridge.render_w)  || (gh != g_bridge.render_h) ||
@@ -4788,11 +4799,12 @@ static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter
             if (g_bridge.partial_output)
             {
                 // The region only. See the note above the partial test.
-                D3D11_BOX box = { 0, 0, 0,
-                                  g_bridge.ngx_out_w < d[SLOT_OUTPUT].Width  ? g_bridge.ngx_out_w : d[SLOT_OUTPUT].Width,
-                                  g_bridge.ngx_out_h < d[SLOT_OUTPUT].Height ? g_bridge.ngx_out_h : d[SLOT_OUTPUT].Height,
-                                  1 };
-                ctx->CopySubresourceRegion(g[SLOT_OUTPUT], 0, 0, 0, 0, g_bridge.tex11[SLOT_OUTPUT], 0, &box);
+                // NGX wrote at the game's output base, not necessarily 0,0.
+                // Copying the origin can overwrite the other split-screen view.
+                D3D11_BOX box = { output_x, output_y, 0,
+                                  output_x + g_bridge.ngx_out_w,
+                                  output_y + g_bridge.ngx_out_h, 1 };
+                ctx->CopySubresourceRegion(g[SLOT_OUTPUT], 0, output_x, output_y, 0, g_bridge.tex11[SLOT_OUTPUT], 0, &box);
             }
             else
                 ctx->CopyResource(g[SLOT_OUTPUT], g_bridge.tex11[SLOT_OUTPUT]);

--- a/src/bridge.inc
+++ b/src/bridge.inc
@@ -1,3 +1,4 @@
+#include "poll-yield.hpp"
 // Implementation of the D3D11 -> D3D12 NGX bridge described in bridge.h.
 
 static NVSDK_NGX_Result SafeEvaluateGuarded(PFN_D3D12EvaluateFeature fn,

--- a/src/dlss5-bridge.cpp
+++ b/src/dlss5-bridge.cpp
@@ -61,7 +61,7 @@
 #pragma comment(lib, "version.lib")
 
 // Kept in step with version.rc, which is where ReShade's overlay reads it from.
-#define BRIDGE_VERSION "1.4.12"
+#define BRIDGE_VERSION "1.4.13-pre1"
 
 extern "C" __declspec(dllexport) const char *NAME =
     "DLSS 5 Bridge " BRIDGE_VERSION;

--- a/src/dlss5-bridge.cpp
+++ b/src/dlss5-bridge.cpp
@@ -61,7 +61,7 @@
 #pragma comment(lib, "version.lib")
 
 // Kept in step with version.rc, which is where ReShade's overlay reads it from.
-#define BRIDGE_VERSION "1.4.13-pre2"
+#define BRIDGE_VERSION "1.4.13-pre3"
 
 extern "C" __declspec(dllexport) const char *NAME =
     "DLSS 5 Bridge " BRIDGE_VERSION;

--- a/src/dlss5-bridge.cpp
+++ b/src/dlss5-bridge.cpp
@@ -61,7 +61,7 @@
 #pragma comment(lib, "version.lib")
 
 // Kept in step with version.rc, which is where ReShade's overlay reads it from.
-#define BRIDGE_VERSION "1.4.13-pre3"
+#define BRIDGE_VERSION "1.4.13-pre4"
 
 extern "C" __declspec(dllexport) const char *NAME =
     "DLSS 5 Bridge " BRIDGE_VERSION;

--- a/src/dlss5-bridge.cpp
+++ b/src/dlss5-bridge.cpp
@@ -61,7 +61,7 @@
 #pragma comment(lib, "version.lib")
 
 // Kept in step with version.rc, which is where ReShade's overlay reads it from.
-#define BRIDGE_VERSION "1.4.13-pre1"
+#define BRIDGE_VERSION "1.4.13-pre2"
 
 extern "C" __declspec(dllexport) const char *NAME =
     "DLSS 5 Bridge " BRIDGE_VERSION;
@@ -2674,6 +2674,16 @@ static int HookNewNgxModules()
         GetModuleFileNameW(mods[i], path, MAX_PATH);
         const wchar_t *leaf = wcsrchr(path, L'\\');
         leaf = leaf ? leaf + 1 : path;
+
+        // FG exports the generic NGX names too, but cannot carry SR calls.
+        // Patching its implementation makes Vulkan FG creation return
+        // FAIL_PlatformError; leave the shared loader hooked, not this snippet.
+        if (_wcsicmp(leaf, L"nvngx_dlssg.dll") == 0)
+        {
+            Log("  leaving %ls untouched: Frame Generation is not an SR entry point.", leaf);
+            RememberRejected(mods[i]);
+            continue;
+        }
 
         // A game that links the NGX client statically exports these from its own
         // executable, and hooking them writes into the game's code section. The

--- a/src/poll-yield.hpp
+++ b/src/poll-yield.hpp
@@ -1,0 +1,38 @@
+#pragma once
+// Reused by each Vulkan worker. A VkEvent has no waitable Win32 handle.
+// Yield for the first millisecond, then poll with a local high-resolution
+// one-shot timer: Sleep(1) may oversleep when the process uses a coarse clock.
+class PollYield {
+    HANDLE timer_ = nullptr;
+    LONGLONG deadline_ = 0, ticks_per_ms_ = 0;
+    ULONGLONG start_ = 0;
+public:
+    PollYield() {
+        LARGE_INTEGER f = {};
+        if (QueryPerformanceFrequency(&f) && f.QuadPart > 0) {
+            ticks_per_ms_ = (f.QuadPart + 999) / 1000;
+            timer_ = CreateWaitableTimerExW(nullptr, nullptr, CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                                           TIMER_MODIFY_STATE | SYNCHRONIZE);
+        }
+    }
+    ~PollYield() { if (timer_) CloseHandle(timer_); }
+    PollYield(const PollYield&) = delete;
+    PollYield& operator=(const PollYield&) = delete;
+    void Start() {
+        LARGE_INTEGER now = {}; QueryPerformanceCounter(&now);
+        deadline_ = now.QuadPart + ticks_per_ms_;
+        start_ = GetTickCount64();
+    }
+    void Pause() {
+        if (timer_) {
+            LARGE_INTEGER now = {}; QueryPerformanceCounter(&now);
+            if (now.QuadPart < deadline_) { SwitchToThread(); return; }
+            LARGE_INTEGER due = {}; due.QuadPart = -10000; // relative 1 ms
+            if (SetWaitableTimer(timer_, &due, 0, nullptr, nullptr, FALSE) &&
+                WaitForSingleObject(timer_, 10) == WAIT_OBJECT_0) return;
+            CloseHandle(timer_); timer_ = nullptr;
+        }
+        // Keep the original polling behavior if the timer is unsupported or fails.
+        if (GetTickCount64() == start_) SwitchToThread(); else Sleep(1);
+    }
+};

--- a/src/synth.inc
+++ b/src/synth.inc
@@ -4641,6 +4641,7 @@ static double SynthNowMs()
 
 static DWORD WINAPI SynthVkParkWorker(LPVOID)
 {
+    PollYield poll_yield;
     for (;;)
     {
         WaitForSingleObject(g_svp.wake, INFINITE);
@@ -4673,9 +4674,10 @@ static DWORD WINAPI SynthVkParkWorker(LPVOID)
             g_svp.take ^= 1;
 
             // Poll rather than wait: a VkEvent signalled by the GPU has no waitable
-            // Win32 handle behind it. SwitchToThread first so a fast frame costs no
-            // sleep quantum, Sleep(1) after the first millisecond so a slow one does
+            // Win32 handle behind it. PollYield bounds the initial spin and uses a
+            // local high-resolution timer for subsequent polls so a slow frame does
             // not burn a core.
+            poll_yield.Start();
             const ULONGLONG t0 = GetTickCount64();
             bool seen = false;
             for (;;)
@@ -4683,7 +4685,7 @@ static DWORD WINAPI SynthVkParkWorker(LPVOID)
                 if (g_svk.EvStatus(g_svk.dev, g_svp.ev_in[slot]) == kSVkEventSet) { seen = true; break; }
                 const ULONGLONG waited = GetTickCount64() - t0;
                 if (waited > kSvpSeeCopiesMs) break;
-                if (waited == 0) SwitchToThread(); else Sleep(1);
+                poll_yield.Pause();
             }
 
             if (seen)

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // ReShade reads the add-on's version from here and shows it in its overlay, so
 // a bug report can name the exact build instead of describing it.
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,4,12,0
- PRODUCTVERSION 1,4,12,0
+ FILEVERSION    1,4,13,1
+ PRODUCTVERSION 1,4,13,1
  FILEOS         VOS_NT_WINDOWS32
  FILETYPE       VFT_DLL
 BEGIN
@@ -13,11 +13,11 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription",  "DLSS 5 Bridge"
-            VALUE "FileVersion",      "1.4.12.0"
+            VALUE "FileVersion",      "1.4.13-pre1"
             VALUE "InternalName",     "dlss5-bridge"
             VALUE "OriginalFilename", "dlss5-bridge.addon64"
             VALUE "ProductName",      "DLSS 5 Bridge"
-            VALUE "ProductVersion",   "1.4.12.0"
+            VALUE "ProductVersion",   "1.4.13-pre1"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // ReShade reads the add-on's version from here and shows it in its overlay, so
 // a bug report can name the exact build instead of describing it.
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,4,13,3
- PRODUCTVERSION 1,4,13,3
+ FILEVERSION    1,4,13,4
+ PRODUCTVERSION 1,4,13,4
  FILEOS         VOS_NT_WINDOWS32
  FILETYPE       VFT_DLL
 BEGIN
@@ -13,11 +13,11 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription",  "DLSS 5 Bridge"
-            VALUE "FileVersion",      "1.4.13-pre3"
+            VALUE "FileVersion",      "1.4.13-pre4"
             VALUE "InternalName",     "dlss5-bridge"
             VALUE "OriginalFilename", "dlss5-bridge.addon64"
             VALUE "ProductName",      "DLSS 5 Bridge"
-            VALUE "ProductVersion",   "1.4.13-pre3"
+            VALUE "ProductVersion",   "1.4.13-pre4"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // ReShade reads the add-on's version from here and shows it in its overlay, so
 // a bug report can name the exact build instead of describing it.
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,4,13,2
- PRODUCTVERSION 1,4,13,2
+ FILEVERSION    1,4,13,3
+ PRODUCTVERSION 1,4,13,3
  FILEOS         VOS_NT_WINDOWS32
  FILETYPE       VFT_DLL
 BEGIN
@@ -13,11 +13,11 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription",  "DLSS 5 Bridge"
-            VALUE "FileVersion",      "1.4.13-pre2"
+            VALUE "FileVersion",      "1.4.13-pre3"
             VALUE "InternalName",     "dlss5-bridge"
             VALUE "OriginalFilename", "dlss5-bridge.addon64"
             VALUE "ProductName",      "DLSS 5 Bridge"
-            VALUE "ProductVersion",   "1.4.13-pre2"
+            VALUE "ProductVersion",   "1.4.13-pre3"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // ReShade reads the add-on's version from here and shows it in its overlay, so
 // a bug report can name the exact build instead of describing it.
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,4,13,1
- PRODUCTVERSION 1,4,13,1
+ FILEVERSION    1,4,13,2
+ PRODUCTVERSION 1,4,13,2
  FILEOS         VOS_NT_WINDOWS32
  FILETYPE       VFT_DLL
 BEGIN
@@ -13,11 +13,11 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription",  "DLSS 5 Bridge"
-            VALUE "FileVersion",      "1.4.13-pre1"
+            VALUE "FileVersion",      "1.4.13-pre2"
             VALUE "InternalName",     "dlss5-bridge"
             VALUE "OriginalFilename", "dlss5-bridge.addon64"
             VALUE "ProductName",      "DLSS 5 Bridge"
-            VALUE "ProductVersion",   "1.4.13-pre1"
+            VALUE "ProductVersion",   "1.4.13-pre2"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/vkmirror.inc
+++ b/src/vkmirror.inc
@@ -534,6 +534,7 @@ static void VkmRefuse(const char *why)
 
 static DWORD WINAPI VkmWorkerProc(LPVOID)
 {
+    PollYield poll_yield;
     for (;;)
     {
         WaitForSingleObject(g_vkm.wake, INFINITE);
@@ -554,10 +555,11 @@ static DWORD WINAPI VkmWorkerProc(LPVOID)
         }
 
         // Poll rather than wait: a VkEvent signalled by the GPU has no waitable
-        // Win32 handle behind it. SwitchToThread first so a fast frame costs no
-        // sleep quantum, Sleep(1) after the first millisecond so a slow one does
+        // Win32 handle behind it. PollYield bounds the initial spin and uses a
+        // local high-resolution timer for subsequent polls so a slow frame does
         // not burn a core.
         const int slot = static_cast<int>(g_vkm.cur);
+        poll_yield.Start();
         const ULONGLONG t0 = GetTickCount64();
         bool seen = false;
         for (;;)
@@ -565,7 +567,7 @@ static DWORD WINAPI VkmWorkerProc(LPVOID)
             if (g_svk.EvStatus(g_svk.dev, g_vkm.ev_in[slot]) == kSVkEventSet) { seen = true; break; }
             const ULONGLONG waited = GetTickCount64() - t0;
             if (waited > kVkmSeeCopiesMs) break;
-            if (waited == 0) SwitchToThread(); else Sleep(1);
+            poll_yield.Pause();
         }
 
         if (seen)

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+/poll-yield.exe
+/poll-yield.obj

--- a/tests/poll-yield.cpp
+++ b/tests/poll-yield.cpp
@@ -1,0 +1,56 @@
+#include <windows.h>
+#include <cassert>
+static LONGLONG clock_ticks;
+static ULONGLONG coarse_ticks;
+static bool frequency_ok, create_ok, set_ok, wait_ok;
+static int creates, closes, yields, sleeps, sets, waits;
+static BOOL WINAPI TestFrequency(LARGE_INTEGER* v) { v->QuadPart=1000000; return frequency_ok; }
+static BOOL WINAPI TestCounter(LARGE_INTEGER* v) { v->QuadPart=clock_ticks; return TRUE; }
+static ULONGLONG WINAPI TestTicks() { return coarse_ticks; }
+static HANDLE WINAPI TestCreate(LPSECURITY_ATTRIBUTES, LPCWSTR, DWORD flags, DWORD access) {
+    assert(flags==CREATE_WAITABLE_TIMER_HIGH_RESOLUTION);
+    assert(access==(TIMER_MODIFY_STATE|SYNCHRONIZE));
+    ++creates; return create_ok ? reinterpret_cast<HANDLE>(1) : nullptr;
+}
+static BOOL WINAPI TestClose(HANDLE h) { assert(h); ++closes; return TRUE; }
+static BOOL WINAPI TestYield() { ++yields; return TRUE; }
+static void WINAPI TestSleep(DWORD ms) { assert(ms==1); ++sleeps; }
+static BOOL WINAPI TestSet(HANDLE, const LARGE_INTEGER* due, LONG period, PTIMERAPCROUTINE cb, LPVOID, BOOL resume) {
+    assert(due->QuadPart==-10000 && period==0 && !cb && !resume); ++sets; return set_ok;
+}
+static DWORD WINAPI TestWait(HANDLE, DWORD ms) { assert(ms==10); ++waits; return wait_ok ? WAIT_OBJECT_0 : WAIT_FAILED; }
+#define QueryPerformanceFrequency TestFrequency
+#define QueryPerformanceCounter TestCounter
+#define GetTickCount64 TestTicks
+#define CreateWaitableTimerExW TestCreate
+#define CloseHandle TestClose
+#define SwitchToThread TestYield
+#define Sleep TestSleep
+#define SetWaitableTimer TestSet
+#define WaitForSingleObject TestWait
+#include "../src/poll-yield.hpp"
+static void Reset() {
+    clock_ticks=0; coarse_ticks=0; frequency_ok=create_ok=set_ok=wait_ok=true;
+    creates=closes=yields=sleeps=sets=waits=0;
+}
+int main() {
+    Reset();
+    { PollYield p; p.Start(); clock_ticks=999; p.Pause(); assert(yields==1 && sets==0);
+      clock_ticks=1000; p.Pause(); assert(sets==1 && waits==1 && sleeps==0);
+      p.Start(); p.Pause(); assert(yields==2 && creates==1); }
+    assert(closes==1);
+    Reset(); create_ok=false;
+    { PollYield p; p.Start(); p.Pause(); ++coarse_ticks; p.Pause(); assert(yields==1 && sleeps==1 && sets==0); }
+    assert(closes==0);
+    Reset(); set_ok=false;
+    { PollYield p; p.Start(); clock_ticks=1000; ++coarse_ticks; p.Pause(); p.Pause();
+      assert(sets==1 && waits==0 && closes==1 && sleeps==2); }
+    assert(closes==1);
+    Reset(); wait_ok=false;
+    { PollYield p; p.Start(); clock_ticks=1000; p.Pause(); p.Pause();
+      assert(sets==1 && waits==1 && closes==1 && yields==2); }
+    assert(closes==1);
+    Reset(); frequency_ok=false;
+    { PollYield p; p.Start(); p.Pause(); assert(creates==0 && yields==1); }
+    assert(closes==0);
+}

--- a/tests/run.cmd
+++ b/tests/run.cmd
@@ -1,0 +1,9 @@
+@echo off
+setlocal
+call "C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\Auxiliary\Build\vcvars64.bat" >nul 2>&1
+if errorlevel 1 exit /b 1
+cd /d "%~dp0"
+cl /nologo /W4 /O2 /EHsc /std:c++17 poll-yield.cpp /Fe:poll-yield.exe
+if errorlevel 1 exit /b 1
+poll-yield.exe
+exit /b %errorlevel%


### PR DESCRIPTION
Prepare v1.4.13-pre4 as a cumulative test release. It retains pre1's D3D11 output-region fix, pre2's Vulkan FG DLL exclusion and pre3's polling behavior, and adds the depth/MV conversion correction already merged in #34. Version fields agree on 1.4.13-pre4; README status and outstanding issues are updated.

Source comparison against immutable pre3 confirms that the rendering changes are limited to #34. Local build, four WARP pixel-conversion cases, PollYield lifecycle/fallback assertions and the background D3D11 spatial-copy Gym check pass (8/8 evaluations, both untouched regions preserved). The spatial test does not validate independent temporal histories or complete BG3 split-screen rendering.

Stable remains v1.4.12. After merge, publish the exact verified and attested main CI artifact as a new immutable prerelease, following RELEASING.md. Do not replace pre3. This release does not claim fixes for #12, #28 or #29, or an Endfield FPS improvement.
