### PR TITLE
Document verified pre4 download and CI provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ Releases and their notes: [github.com/NIGos/dlss5-bridge/releases](https://githu
 remains the stable release. `main` contains the cumulative 1.4.13 prerelease
 changes and the [D3D11 depth/MV conversion fix](https://github.com/NIGos/dlss5-bridge/pull/34).
 The latest published test build is
-[v1.4.13-pre3](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre3).
+[v1.4.13-pre4](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre4),
+which includes those changes and is the first release with verified GitHub
+Actions build provenance. It is still unsigned; follow the
+[download verification instructions](VERIFYING-DOWNLOADS.md) before loading it.
 BG3 split-screen rendering and coexistence with its Vulkan FG mod remain open
 issues. The Endfield reporter found no FPS improvement from pre3.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,10 +41,16 @@ Their original tags, publication dates and addon files were preserved, and their
 release attestations were verified. Their assets and associated tags are now
 locked. Check any other release's actual status instead of assuming from its version.
 
-The attestation identifies what GitHub published for this repository and tag.
+**v1.4.13-pre4** was published as an immutable release with both a release
+attestation and GitHub Actions build provenance. It is the first release whose
+download can also be verified against the source commit and official build
+workflow that produced it. It remains unsigned: build provenance is not an
+Authenticode publisher signature.
+
+The release attestation identifies what GitHub published for this repository and tag.
 It is not an independent audit of the source or proof that a binary is harmless.
 Build provenance is a separate attestation that links a file to the source
-commit and GitHub Actions workflow that produced it. The five releases above
+commit and GitHub Actions workflow that produced it. The five older releases
 have release attestations, but **no CI build provenance or Authenticode publisher
 signature**. Locking their existing files does not establish how they were
 originally built. Follow the verification instructions for the specific release.

--- a/VERIFYING-DOWNLOADS.md
+++ b/VERIFYING-DOWNLOADS.md
@@ -28,6 +28,7 @@ These values were checked against downloaded official GitHub assets on
 | Release | Asset bytes | SHA-256 of `dlss5-bridge.addon64` |
 | --- | ---: | --- |
 | [v1.4.12 — stable](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.12) | 508928 | `4f2acecc1026ae89ac0b92767be66ceea2662ad0ef88710b89c7da7840d548d4` |
+| [v1.4.13-pre4](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre4) | 513024 | `710e5354c42ae3491c9523576c82805d0c42383836525f3d3d02a31ffa9f9d2f` |
 | [v1.4.13-pre3](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre3) | 508928 | `3dc81b261377c936c22cf8589d96cb0be8b18b8de90d1cea5ba83e9bca763717` |
 | [v1.4.13-pre2](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre2) | 508928 | `2a3e8b74df4fb837841eeebb456cda9cff67ad5b782b14a7b886d90d8d4c333b` |
 | [v1.4.13-pre1](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre1) | 508928 | `59bbc7b111d766c9a325870ba694084da76fbd96ba5aa48a8f0348d2062b6403` |
@@ -50,7 +51,7 @@ From the folder containing that script, run:
 .\Verify-Bridge.ps1 -Path 'C:\Users\YourName\Downloads\dlss5-bridge.addon64' -ReleaseTag v1.4.12
 ```
 
-For another release, supply its tag explicitly, for example `v1.4.13-pre3`.
+For another release, supply its tag explicitly, for example `v1.4.13-pre4`.
 If PowerShell blocks the downloaded script, use the manual hash comparison
 above; weakening execution policy is not required for verification.
 
@@ -63,10 +64,10 @@ above; weakening execution policy is not required for verification.
 
 ## Verify an immutable release
 
-**All five releases in the table above are now immutable and have verified
-release attestations.** Their notes were updated on 9 September 2026, which
-finalized immutability for these existing releases. Their original tags,
-publication dates and addon hashes were preserved.
+**All six releases in the table above are immutable and have verified release
+attestations.** Pre4 was published as an immutable release. The five older
+releases became immutable when their notes were updated on 9 September 2026;
+their original tags, publication dates and addon hashes were preserved.
 
 With a current GitHub CLI, replace `TAG` and the file path with the intended
 release and your local addon:
@@ -85,15 +86,19 @@ attestation.
 
 ## Verify where a CI build came from
 
-The five releases above **do not have CI build provenance**. Their release
-attestations do not add it retroactively.
+**v1.4.13-pre4 is the first release with GitHub Actions build provenance.**
+Its addon comes from the official build workflow on a GitHub-hosted runner.
+The source is [efc5cac43adac2cca98a163afacee5ac1b16917e](https://github.com/NIGos/dlss5-bridge/commit/efc5cac43adac2cca98a163afacee5ac1b16917e),
+from [build run 34342819589](https://github.com/NIGos/dlss5-bridge/actions/runs/34342819589).
 
-For releases that provide GitHub Actions build provenance, the release notes
-identify the source commit and build run. With a current GitHub CLI, replace
-`COMMIT_SHA` with that full commit SHA and supply the downloaded addon's path:
+The five older releases in the table (**v1.4.12, pre1, pre2, pre3 and v1.3.0**)
+**do not have CI build provenance**. Their release attestations do not add it
+retroactively.
+
+To verify pre4 with a current GitHub CLI, replace only the file path:
 
 ```powershell
-gh attestation verify 'C:\path\dlss5-bridge.addon64' --repo NIGos/dlss5-bridge --hostname github.com --signer-workflow NIGos/dlss5-bridge/.github/workflows/verify-download-checker.yml --source-ref refs/heads/main --source-digest COMMIT_SHA --deny-self-hosted-runners
+gh attestation verify 'C:\path\dlss5-bridge.addon64' --repo NIGos/dlss5-bridge --hostname github.com --signer-workflow NIGos/dlss5-bridge/.github/workflows/verify-download-checker.yml --source-ref refs/heads/main --source-digest efc5cac43adac2cca98a163afacee5ac1b16917e --deny-self-hosted-runners
 ```
 
 This checks that the file was attested by the named build workflow for that


### PR DESCRIPTION
Link the published pre4 release and its verified SHA-256, byte size, source commit and CI run. Distinguish its build provenance from the five older immutable releases, retain unsigned status and keep v1.4.12 as stable. The public addon download matches the tested CI artifact; build provenance, release attestation and all three release assets verified successfully.