### PR TITLE
Fix Vulkan Frame Generation device selection

### DIFF
--- a/.github/workflows/verify-download-checker.yml
+++ b/.github/workflows/verify-download-checker.yml
@@ -30,6 +30,9 @@ jobs:
       - name: D3D11 conversion pixels (WARP)
         shell: cmd
         run: call tests\build-d3d11-conversion-test.cmd --warp
+      - name: Vulkan FG device routing (CPU)
+        shell: cmd
+        run: call tests\build-vulkan-fg-device-test.cmd
       - name: Record build and checksums
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -34,13 +34,19 @@ Releases and their notes: [github.com/NIGos/dlss5-bridge/releases](https://githu
 **Release status (9 September 2026).** [v1.4.12](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.12)
 remains the stable release. `main` contains the cumulative 1.4.13 prerelease
 changes and the [D3D11 depth/MV conversion fix](https://github.com/NIGos/dlss5-bridge/pull/34).
+The next test build, pre5, also fixes a Vulkan Frame Generation startup failure
+reported in [Endfield](https://github.com/NIGos/dlss5-bridge/issues/27#issuecomment-5606803978):
+it supplies the command buffer's device when NGX cannot infer one alongside
+the Bridge's private device, and clears obsolete hooks when an NGX module unloads.
 The latest published test build is
 [v1.4.13-pre4](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre4),
 which includes those changes and is the first release with verified GitHub
 Actions build provenance. It is still unsigned; follow the
 [download verification instructions](VERIFYING-DOWNLOADS.md) before loading it.
-BG3 split-screen rendering and coexistence with its Vulkan FG mod remain open
-issues. The Endfield reporter found no FPS improvement from pre3.
+BG3 split-screen rendering remains open. A [BG3 reporter confirmed SR/mirror/FG
+coexistence with pre4](https://github.com/NIGos/dlss5-bridge/issues/28#issuecomment-5607261784);
+visual neural-output confirmation is still pending. The Endfield mirror slowdown
+remains unresolved; the FG startup fix does not establish an FPS improvement.
 
 Some neural add-ons support additional graphics APIs directly. Whether you need
 this bridge depends on the add-on build and the game. See the compatibility

--- a/src/dlss5-bridge.cpp
+++ b/src/dlss5-bridge.cpp
@@ -58,10 +58,12 @@
 #include <cstdio>
 #include <cstdarg>
 #include <cstdint>
+#include <mutex>
+#include <unordered_map>
 #pragma comment(lib, "version.lib")
 
 // Kept in step with version.rc, which is where ReShade's overlay reads it from.
-#define BRIDGE_VERSION "1.4.13-pre4"
+#define BRIDGE_VERSION "1.4.13-pre5"
 
 extern "C" __declspec(dllexport) const char *NAME =
     "DLSS 5 Bridge " BRIDGE_VERSION;
@@ -2746,13 +2748,14 @@ static int HookNewNgxModules()
         // Slots used to be handed out forward only, so every unload and reload
         // of an NGX module burned one permanently and a long session could run
         // out of a table it was no longer using. ForgetUnloadedLayer nulls mod,
-        // which is what makes a slot free: HookInstall overwrites a slot whole
-        // and LAYER_DETOURS binds by index, so reuse is safe.
+        // which is what makes a slot free. Reset every hook before reuse: the
+        // replacement module may not export all the old module's entry points.
         LONG slot = g_layer_count;
         for (LONG k = 0; k < g_layer_count; ++k)
             if (g_layer[k].mod == nullptr) { slot = k; break; }
 
         Layer &L = g_layer[slot];
+        L = {};
         L.mod = mods[i];
 
         Log("NGX layer %ld: %ls (base=%p)", slot, path, static_cast<void *>(mods[i]));
@@ -3518,8 +3521,7 @@ static void ForgetUnloadedLayer(const void *base)
     {
         if (g_layer[i].mod == nullptr ||
             static_cast<const void *>(g_layer[i].mod) != base) continue;
-        g_layer[i].eval.active = g_layer[i].eval_c.active = g_layer[i].create.active = false;
-        g_layer[i].mod = nullptr;
+        g_layer[i] = {};
         Log("NGX layer %ld has been unloaded; its hooks are dropped rather than "
             "called into or written back to memory that is gone.", i);
     }

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // ReShade reads the add-on's version from here and shows it in its overlay, so
 // a bug report can name the exact build instead of describing it.
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,4,13,4
- PRODUCTVERSION 1,4,13,4
+ FILEVERSION    1,4,13,5
+ PRODUCTVERSION 1,4,13,5
  FILEOS         VOS_NT_WINDOWS32
  FILETYPE       VFT_DLL
 BEGIN
@@ -13,11 +13,11 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription",  "DLSS 5 Bridge"
-            VALUE "FileVersion",      "1.4.13-pre4"
+            VALUE "FileVersion",      "1.4.13-pre5"
             VALUE "InternalName",     "dlss5-bridge"
             VALUE "OriginalFilename", "dlss5-bridge.addon64"
             VALUE "ProductName",      "DLSS 5 Bridge"
-            VALUE "ProductVersion",   "1.4.13-pre4"
+            VALUE "ProductVersion",   "1.4.13-pre5"
         END
     END
     BLOCK "VarFileInfo"

--- a/src/vkmirror.inc
+++ b/src/vkmirror.inc
@@ -334,6 +334,46 @@ static VkMirror g_vkm;
 // frames -- which is exactly what the two-ReShades check below tests.
 static reshade::api::effect_runtime *g_vkm_rt;
 
+// A legacy FG create names a command buffer but no device. ReShade knows its
+// owner at allocation time; an effect runtime may belong to another VkDevice.
+// Only allocation/free and FG creation touch this table, never draw/evaluate.
+static std::mutex g_vkm_cmd_mutex;
+static std::unordered_map<uint64_t, uint64_t> g_vkm_cmd_devices;
+
+static void OnVkmInitCommandList(reshade::api::command_list *cmd)
+{
+    auto *dev = cmd->get_device();
+    if (dev->get_api() != reshade::api::device_api::vulkan) return;
+    std::lock_guard<std::mutex> lock(g_vkm_cmd_mutex);
+    g_vkm_cmd_devices[cmd->get_native()] = dev->get_native();
+}
+
+static void OnVkmDestroyCommandList(reshade::api::command_list *cmd)
+{
+    if (cmd->get_device()->get_api() != reshade::api::device_api::vulkan) return;
+    std::lock_guard<std::mutex> lock(g_vkm_cmd_mutex);
+    g_vkm_cmd_devices.erase(cmd->get_native());
+}
+
+static void OnVkmDestroyDevice(reshade::api::device *dev)
+{
+    if (dev->get_api() != reshade::api::device_api::vulkan) return;
+    const uint64_t native = dev->get_native();
+    std::lock_guard<std::mutex> lock(g_vkm_cmd_mutex);
+    // A command pool can be destroyed without individual command-list events.
+    for (auto it = g_vkm_cmd_devices.begin(); it != g_vkm_cmd_devices.end(); )
+        if (it->second == native) it = g_vkm_cmd_devices.erase(it);
+        else ++it;
+}
+
+static void *VkmCommandDevice(void *cmd)
+{
+    std::lock_guard<std::mutex> lock(g_vkm_cmd_mutex);
+    const auto it = g_vkm_cmd_devices.find(reinterpret_cast<uintptr_t>(cmd));
+    return it != g_vkm_cmd_devices.end()
+        ? reinterpret_cast<void *>(static_cast<uintptr_t>(it->second)) : nullptr;
+}
+
 // A runtime arrives. On Vulkan this happens again after every swapchain change,
 // so it is also where the stand-down VkmShutdown raised is lifted -- the mirror
 // rebuilds itself on the next evaluate.
@@ -497,6 +537,9 @@ static void VkmRegisterEvents()
     }
     reg(reshade::addon_event::init_effect_runtime,    reinterpret_cast<void *>(&OnVkmInitRuntime));
     reg(reshade::addon_event::destroy_effect_runtime, reinterpret_cast<void *>(&OnVkmDestroyRuntime));
+    reg(reshade::addon_event::init_command_list,      reinterpret_cast<void *>(&OnVkmInitCommandList));
+    reg(reshade::addon_event::destroy_command_list,   reinterpret_cast<void *>(&OnVkmDestroyCommandList));
+    reg(reshade::addon_event::destroy_device,         reinterpret_cast<void *>(&OnVkmDestroyDevice));
     Log("[vkmirror] vk_mirror=1: the Vulkan NGX entry points will be hooked and a Vulkan "
         "game's own DLSS contract mirrored onto the private D3D12 session.");
 }
@@ -1971,8 +2014,29 @@ static NVSDK_NGX_Result ForwardVkCreate(Hook &h, void *cmd, int feature_id,
     // worker is inside its own evaluate is the same two-threads-in-one-NGX shape.
     if (g_ngx_cs_ready) EnterCriticalSection(&g_ngx_cs);
     EnterCriticalSection(&g_hook_cs);
+    // NGX requires CreateFeature1 when multiple devices are active. The private
+    // D3D12 session makes legacy Vulkan FG device inference ambiguous (#27).
+    // Use the command buffer's observed owner, not the last presenting runtime.
+    // Unknown owners/exports and every other feature retain the original path.
+    void *vkdev = feature_id == 11 ? VkmCommandDevice(cmd) : nullptr;
+    Hook *named = nullptr;
+    if (vkdev != nullptr)
+        for (LONG i = 0; i < g_layer_count && i < kMaxLayers; ++i)
+            if (&g_layer[i].vk_create == &h && g_layer[i].mod != nullptr &&
+                g_layer[i].vk_create1.target != nullptr)
+            { named = &g_layer[i].vk_create1; break; }
     HookRemove(h);
-    NVSDK_NGX_Result r = fwd(cmd, feature_id, p, out);
+    NVSDK_NGX_Result r;
+    if (named != nullptr)
+    {
+        Log("[vkmirror] creating Frame Generation through CreateFeature1 with the "
+            "command buffer's VkDevice %p.", vkdev);
+        HookRemove(*named);
+        r = reinterpret_cast<PFN_VkCreate1>(named->target)(vkdev, cmd, feature_id, p, out);
+        HookRestore(*named);
+    }
+    else
+        r = fwd(cmd, feature_id, p, out);
     HookRestore(h);
     LeaveCriticalSection(&g_hook_cs);
     if (g_ngx_cs_ready) LeaveCriticalSection(&g_ngx_cs);

--- a/tests/build-vulkan-fg-device-test.cmd
+++ b/tests/build-vulkan-fg-device-test.cmd
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+rem CPU-only production Vulkan create test. --build-only skips execution.
+if defined VCVARS goto toolchain_found
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+  echo test: Visual Studio Installer vswhere.exe was not found; set VCVARS to vcvars64.bat
+  exit /b 1
+)
+for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VCVARS=%%I\VC\Auxiliary\Build\vcvars64.bat"
+:toolchain_found
+if not exist "%VCVARS%" (
+  echo test: no vcvars64.bat at "%VCVARS%"
+  exit /b 1
+)
+call "%VCVARS%" >nul 2>&1
+if errorlevel 1 exit /b 1
+cd /d "%~dp0"
+if not exist build mkdir build
+if errorlevel 1 exit /b 1
+cl /nologo /W4 /O2 /MT /EHsc /std:c++17 /I..\src\reshade ^
+   /Fo:build\ /Fe:build\vulkan-fg-device.exe vulkan-fg-device.cpp ^
+   /link user32.lib advapi32.lib bcrypt.lib
+if errorlevel 1 exit /b 1
+if /i "%~1"=="--build-only" exit /b 0
+cd build
+vulkan-fg-device.exe
+exit /b %ERRORLEVEL%

--- a/tests/vulkan-fg-device.cpp
+++ b/tests/vulkan-fg-device.cpp
@@ -1,0 +1,159 @@
+// CPU-only calls through the production Vulkan create wrappers. No Vulkan,
+// D3D, NGX, ReShade runtime or patched function bytes are needed.
+#include "../src/dlss5-bridge.cpp"
+
+// Negative control: compile this same test against unmodified pre4 with
+// /DBRIDGE_TEST_LEGACY_FG. Supply only the ownership input absent in that version;
+// its production forwarding must still fail the mapped-FG expectation.
+#ifdef BRIDGE_TEST_LEGACY_FG
+#include <unordered_map>
+static std::unordered_map<uint64_t, uint64_t> g_vkm_cmd_devices;
+#endif
+
+#define EXPECT(condition) do { if (!(condition)) { \
+    printf("FAIL line %d: %s\n", __LINE__, #condition); exit(1); } } while (0)
+
+struct RecordedCall {
+    int count, layer, feature, nesting;
+    void *device, *command;
+    NVSDK_NGX_Parameter *params;
+    NVSDK_NGX_Handle **out;
+};
+static RecordedCall g_call;
+static NVSDK_NGX_Result g_return_result;
+static NVSDK_NGX_Handle g_handle = {42};
+static NVSDK_NGX_Handle *g_return_handle;
+static SynthParams g_params;
+
+static NVSDK_NGX_Result Record(int layer, void *device, void *command, int feature,
+                              NVSDK_NGX_Parameter *params, NVSDK_NGX_Handle **out)
+{
+    g_call = {g_call.count + 1, layer, feature, g_nest, device, command, params, out};
+    if (out != nullptr) *out = g_return_handle;
+    return g_return_result;
+}
+
+static NVSDK_NGX_Result Legacy0(void *c, int f, NVSDK_NGX_Parameter *p, NVSDK_NGX_Handle **o)
+{ return Record(0, nullptr, c, f, p, o); }
+static NVSDK_NGX_Result Legacy1(void *c, int f, NVSDK_NGX_Parameter *p, NVSDK_NGX_Handle **o)
+{ return Record(1, nullptr, c, f, p, o); }
+static NVSDK_NGX_Result Named0(void *d, void *c, int f, NVSDK_NGX_Parameter *p, NVSDK_NGX_Handle **o)
+{ return Record(0, d, c, f, p, o); }
+static NVSDK_NGX_Result Named1(void *d, void *c, int f, NVSDK_NGX_Parameter *p, NVSDK_NGX_Handle **o)
+{ return Record(1, d, c, f, p, o); }
+
+static void CheckForward(const char *name, Hook &hook, void *command, int feature,
+                         void *expected_device, int expected_layer = 0,
+                         NVSDK_NGX_Result result = NGX_SUCCESS,
+                         NVSDK_NGX_Handle *handle = &g_handle, bool null_out = false)
+{
+    printf("CASE: %s\n", name);
+    g_call = {};
+    g_return_result = result;
+    g_return_handle = handle;
+    const int nesting = g_nest;
+    const LONG creates = g_create_count;
+    const bool observed = nesting == 0 && reinterpret_cast<uintptr_t>(command) >= 0x10000;
+    // A reused SR handle must lose its old non-SR classification.
+    g_other_feature_count = feature == 1 ? 1 : 0;
+    g_other_feature[0] = &g_handle;
+    g_s12.w = 777;
+    g_s12.need_reset = false;
+    g_vkm.rebuild_on_game_create = false;
+    NVSDK_NGX_Handle *out = nullptr;
+    auto **output_arg = null_out ? nullptr : &out;
+    const auto actual = ForwardVkCreate(hook, command, feature, &g_params, output_arg);
+    EXPECT(actual == result);
+    EXPECT(out == (null_out ? nullptr : handle));
+    EXPECT(g_call.count == 1 && g_call.layer == expected_layer);
+    EXPECT(g_call.device == expected_device && g_call.command == command);
+    EXPECT(g_call.feature == feature && g_call.params == &g_params && g_call.out == output_arg);
+    EXPECT(g_call.nesting == (nesting != 0 ? nesting : 1) && g_nest == nesting);
+    EXPECT(g_create_count == creates + (observed ? 1 : 0));
+    const bool recorded = observed && result == NGX_SUCCESS && !null_out && handle != nullptr;
+    EXPECT(g_other_feature_count == (feature == 1 ? (recorded ? 0 : 1) : (recorded ? 1 : 0)));
+    if (recorded && feature != 1) EXPECT(IsOtherFeature(handle));
+    const bool rebuild = observed && feature == 1 && result == NGX_SUCCESS;
+    EXPECT(g_s12.w == (rebuild ? 0u : 777u));
+    EXPECT(g_s12.need_reset == rebuild && g_vkm.rebuild_on_game_create == rebuild);
+    if (rebuild)
+        EXPECT(g_vkm.cw == 640 && g_vkm.ch == 360 && g_vkm.cow == 1280 && g_vkm.coh == 720);
+    EXPECT(!hook.active); // Never write instructions in the CPU harness.
+    puts("PASS");
+}
+
+int main()
+{
+    InitializeCriticalSection(&g_log_cs);
+    InitializeCriticalSection(&g_hook_cs);
+    InitializeCriticalSection(&g_ngx_cs);
+    InitializeCriticalSection(&g_bridge_cs);
+    g_ngx_cs_ready = true;
+    strcpy_s(g_log_path, "NUL");
+    g_params.Set("Width", 640u); g_params.Set("Height", 360u);
+    g_params.Set("OutWidth", 1280u); g_params.Set("OutHeight", 720u);
+    g_layer_count = 2;
+    g_layer[0].mod = reinterpret_cast<HMODULE>(static_cast<uintptr_t>(0x100000));
+    g_layer[1].mod = reinterpret_cast<HMODULE>(static_cast<uintptr_t>(0x200000));
+    g_layer[0].vk_create.target = reinterpret_cast<BYTE *>(&Legacy0);
+    g_layer[0].vk_create1.target = reinterpret_cast<BYTE *>(&Named0);
+    g_layer[1].vk_create.target = reinterpret_cast<BYTE *>(&Legacy1);
+    g_layer[1].vk_create1.target = reinterpret_cast<BYTE *>(&Named1);
+    // Opaque, distinct dispatchable handles; production must never dereference them.
+    uint64_t command_a = 0, command_b = 0, unknown = 0, device_a = 0, device_b = 0;
+    g_vkm_cmd_devices[reinterpret_cast<uintptr_t>(&command_a)] = reinterpret_cast<uintptr_t>(&device_a);
+    g_vkm_cmd_devices[reinterpret_cast<uintptr_t>(&command_b)] = reinterpret_cast<uintptr_t>(&device_b);
+
+    CheckForward("FG command A names device A", g_layer[0].vk_create, &command_a, 11, &device_a);
+    CheckForward("FG command B names device B in its own layer", g_layer[1].vk_create, &command_b, 11, &device_b, 1);
+    CheckForward("FG command A still names A after B", g_layer[0].vk_create, &command_a, 11, &device_a);
+    CheckForward("unknown command retains legacy call", g_layer[0].vk_create, &unknown, 11, nullptr);
+    g_vkm_cmd_devices.erase(reinterpret_cast<uintptr_t>(&command_a));
+    CheckForward("removed ownership retains legacy call", g_layer[0].vk_create, &command_a, 11, nullptr);
+    g_vkm_cmd_devices[reinterpret_cast<uintptr_t>(&command_a)] = reinterpret_cast<uintptr_t>(&device_a);
+    g_layer[0].vk_create1.target = nullptr;
+    CheckForward("missing sibling cannot borrow another layer's CreateFeature1", g_layer[0].vk_create, &command_a, 11, nullptr);
+    g_layer[0].vk_create1.target = reinterpret_cast<BYTE *>(&Named0);
+    Hook outside = {}; outside.target = reinterpret_cast<BYTE *>(&Legacy0);
+    CheckForward("unregistered hook retains legacy call", outside, &command_a, 11, nullptr);
+    g_nest = 1;
+    CheckForward("nested FG retains legacy call without double accounting", g_layer[0].vk_create, &command_a, 11, nullptr);
+    g_nest = 0;
+    CheckForward("SR retains legacy call and invalidates reused non-SR handle", g_layer[0].vk_create, &command_a, 1, nullptr);
+    CheckForward("other feature retains legacy call and accounting", g_layer[0].vk_create, &command_a, 2, nullptr);
+    CheckForward("invalid command retains legacy call without accounting", g_layer[0].vk_create, nullptr, 11, nullptr);
+    const auto failure = static_cast<NVSDK_NGX_Result>(0xBAD00001);
+    CheckForward("named failure propagates and does not record returned handle", g_layer[0].vk_create, &command_a, 11, &device_a, 0, failure);
+    CheckForward("legacy failure propagates", g_layer[0].vk_create, &unknown, 11, nullptr, 0, failure);
+    CheckForward("null returned handle is not recorded", g_layer[0].vk_create, &command_a, 11, &device_a, 0, NGX_SUCCESS, nullptr);
+    CheckForward("null output argument is forwarded", g_layer[0].vk_create, &command_a, 11, &device_a, 0, NGX_SUCCESS, &g_handle, true);
+    g_ngx_cs_ready = false;
+    CheckForward("FG forwarding before NGX lock readiness", g_layer[0].vk_create, &command_b, 11, &device_b);
+
+    puts("CASE: unloading a module clears all seven hooks and preserves its peer");
+    Hook *hooks[] = {&g_layer[0].eval, &g_layer[0].eval_c, &g_layer[0].create,
+                    &g_layer[0].vk_eval, &g_layer[0].vk_eval_c,
+                    &g_layer[0].vk_create, &g_layer[0].vk_create1};
+    for (auto *hook : hooks) {
+        hook->target = reinterpret_cast<BYTE *>(&Legacy0);
+        hook->active = true; // Unload must discard state without patching freed code.
+    }
+    BYTE peer[sizeof(Layer)]; memcpy(peer, &g_layer[1], sizeof(peer));
+    ForgetUnloadedLayer(g_layer[0].mod);
+    EXPECT(g_layer[0].mod == nullptr);
+    for (const auto *hook : hooks) EXPECT(hook->target == nullptr && !hook->active);
+    EXPECT(memcmp(peer, &g_layer[1], sizeof(peer)) == 0);
+    puts("PASS");
+    // Even an unowned slot with a nonnull stale sibling may not select it.
+    g_layer[0].vk_create.target = reinterpret_cast<BYTE *>(&Legacy0);
+    g_layer[0].vk_create1.target = reinterpret_cast<BYTE *>(&Named0);
+    CheckForward("unowned layer cannot select a stale sibling", g_layer[0].vk_create, &command_a, 11, nullptr);
+
+    g_vkm_cmd_devices.clear();
+    DeleteCriticalSection(&g_bridge_cs);
+    DeleteCriticalSection(&g_ngx_cs);
+    DeleteCriticalSection(&g_hook_cs);
+    DeleteCriticalSection(&g_log_cs);
+    puts("PASS: production Vulkan FG device routing, fallbacks and handle accounting (CPU only)");
+    return 0;
+}


### PR DESCRIPTION
Vulkan Frame Generation can fail with `0xBAD00005` after the Bridge opens its private D3D12 NGX session: legacy `CreateFeature` leaves the device unspecified. This reproduces in the Gym with pre4 and FG 310.9; the same call succeeds without Bridge and with this change.

Based on @Puntoe's diagnosis and patch in #27, route FG creates through the same NGX layer's `CreateFeature1`. ReShade command-list lifecycle events supply the actual owning device, so this also handles multiple Vulkan devices without guessing from the last effect runtime. Unknown command owners, absent sibling exports, nested calls and other feature types retain their existing path. Discard all hook records on module unload/reuse to prevent stale Vulkan exports being selected. Version: 1.4.13-pre5.

Validation:

- CPU regression exercises production forwarding, two devices/layers, fallbacks, handle bookkeeping and unload cleanup. The same test fails behaviorally on unmodified pre4.
- Gym: pre4 fails legacy FG creation after 120 mirrored SR frames; candidate succeeds with and without NR. Explicit-device FG creation also succeeds.
- MFG 4x with NR: 30 SR frames, 90 generated evaluations, three finite output captures; no new Vulkan validation categories (three existing categories remain).
- D3D11 WARP pixel checks pass. The local D3D11 debug layer is unavailable; CI runs the existing check too.

This addresses the new FG startup report, not the separate Endfield mirror slowdown. BG3's new positive pre4 report does not establish a general hook-coexistence or HDR fix. No games or performance benchmarks run. Related: #27, #28.
