### PR TITLE
Keep separate D3D11 temporal histories for split-screen views

### DIFF
--- a/.github/workflows/verify-download-checker.yml
+++ b/.github/workflows/verify-download-checker.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Vulkan FG device routing (CPU)
         shell: cmd
         run: call tests\build-vulkan-fg-device-test.cmd
+      - name: D3D11 temporal history ownership (CPU)
+        shell: cmd
+        run: call tests\build-d3d11-histories-test.cmd
       - name: Record build and checksums
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ development:
 
 Releases and their notes: [github.com/NIGos/dlss5-bridge/releases](https://github.com/NIGos/dlss5-bridge/releases).
 
-**Release status (9 September 2026).** [v1.4.12](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.12)
+**Release status (10 September 2026).** [v1.4.12](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.12)
 remains the stable release. `main` contains the cumulative 1.4.13 prerelease
 changes and the [D3D11 depth/MV conversion fix](https://github.com/NIGos/dlss5-bridge/pull/34).
 The latest test build, [v1.4.13-pre5](https://github.com/NIGos/dlss5-bridge/releases/tag/v1.4.13-pre5),
@@ -42,9 +42,14 @@ the Bridge's private device, and clears obsolete hooks when an NGX module unload
 Pre5 includes all pre4 changes and has verified GitHub Actions build provenance.
 It is still unsigned; follow the
 [download verification instructions](VERIFYING-DOWNLOADS.md) before loading it.
-BG3 split-screen rendering remains open. The [BG3 FG reporter](https://github.com/NIGos/dlss5-bridge/issues/28#issuecomment-5609017168)
+On `main`, distinct D3D11 DLSS features now keep separate temporal histories,
+including same-sized split-screen views. Background Gym tests reproduce the
+shared-history defect in pre5 and pass with the correction; confirmation in BG3
+is still needed. BG3 split-screen rendering remains open. The [BG3 FG reporter](https://github.com/NIGos/dlss5-bridge/issues/28#issuecomment-5609017168)
 confirmed neural output, but also tested local hook changes and newer Streamline
 files; flickering/ghosting and general hook coexistence remain under investigation.
+The [Endfield reporter](https://github.com/NIGos/dlss5-bridge/issues/27#issuecomment-5609207523)
+confirmed DLAA + MFG 4x + neural rendering working together on pre5.
 The Endfield mirror slowdown
 remains unresolved; the FG startup fix does not establish an FPS improvement.
 

--- a/src/bridge.h
+++ b/src/bridge.h
@@ -237,6 +237,10 @@ struct Bridge
 
     NVSDK_NGX_Parameter *params;
     NVSDK_NGX_Handle    *feature;
+    // One temporal history per game feature, sharing the ordered transport.
+    // Invalidated together when the resource shape or create contract changes.
+    struct History { const NVSDK_NGX_Handle *game; NVSDK_NGX_Handle *feature; };
+    History histories[8];
 
     // The exposure texture is kept apart from the slot array rather than made a
     // fifth slot: every SLOT_COUNT loop dereferences its entry unconditionally,

--- a/src/bridge.inc
+++ b/src/bridge.inc
@@ -367,12 +367,18 @@ static void TimingTick(LONGLONG entry, LONGLONG exit)
 // flags below still read healthy while the frames behind them were produced by
 // somebody else, and skipping the game on that evidence leaves the last mirrored
 // image on screen under live audio and live input.
-static bool BridgeWillDeliver()
+static bool BridgeWillDeliver(const NVSDK_NGX_Handle *handle)
 {
-    return g_source == SRC_MIRROR &&
+    EnterCriticalSection(&g_bridge_cs);
+    bool known = false;
+    for (const auto &history : g_bridge.histories)
+        if (history.feature != nullptr && history.game == handle) known = true;
+    const bool deliver = known && g_source == SRC_MIRROR &&
            g_cfg.skip_game != 0 && g_cfg.mode == 2 && g_cfg.stage >= 3 &&
            !g_bridge.disabled && !g_bridge.stalled && g_bridge.session_ready && g_bridge.frame_ready &&
            !g_bridge.partial_output && g_bridge.frames_done > 0;
+    LeaveCriticalSection(&g_bridge_cs);
+    return deliver;
 }
 
 // The add-on was called dlss5-dx11-bridge up to and including 1.1.0 -- the rename
@@ -2212,11 +2218,21 @@ static void BridgeReleaseTextures()
         if (g_bridge.tex12[i]  != nullptr) { g_bridge.tex12[i]->Release();  g_bridge.tex12[i]  = nullptr; }
         if (g_bridge.shared[i] != nullptr) { CloseHandle(g_bridge.shared[i]); g_bridge.shared[i] = nullptr; }
     }
-    if (g_bridge.feature != nullptr && g_bridge.release_feature != nullptr)
+    bool current_owned = false;
+    for (auto &history : g_bridge.histories)
+    {
+        if (history.feature != nullptr)
+        {
+            if (history.feature == g_bridge.feature) current_owned = true;
+            if (g_bridge.release_feature != nullptr) g_bridge.release_feature(history.feature);
+        }
+        history = {};
+    }
+    if (!current_owned && g_bridge.feature != nullptr && g_bridge.release_feature != nullptr)
     {
         g_bridge.release_feature(g_bridge.feature);
-        g_bridge.feature = nullptr;
     }
+    g_bridge.feature = nullptr;
     g_bridge.frame_ready = false;
 }
 
@@ -2938,6 +2954,11 @@ static bool MakeSharedPair(ID3D11Device *dev11, ID3D11Device1 *dev1, int i,
 // upscaling mode the Output texture is larger than the inputs, and the rendered
 // area is smaller than the texture that holds it.
 static void CopyUIntParam(const NVSDK_NGX_Parameter *src, const char *key, unsigned int fallback);
+static bool BridgeCreatedUInt(const char *key, unsigned int *value);
+static bool BridgeCreateUInt(const NVSDK_NGX_Parameter *gp, const char *key, unsigned int *value)
+{
+    return BridgeCreatedUInt(key, value) || (gp != nullptr && gp->Get(key, value) == NGX_SUCCESS);
+}
 
 // One field, three meanings: g_cfg.flags carries the user's forced value, -1 for
 // "copy whoever is driving", and 107 for the default this add-on shipped before
@@ -3008,6 +3029,8 @@ static unsigned int ResolveCreateFlags(const NVSDK_NGX_Parameter *gp, FlagsFrom 
     *from = FLAGS_NONE;
     return 107u;
 }
+
+static bool BridgeCreateViewFeature(const DXGI_FORMAT *fmt, const NVSDK_NGX_Parameter *gp);
 
 static bool BridgeBuildResources(ID3D11Device *dev11, const DXGI_FORMAT *fmt,
                                  const NVSDK_NGX_Parameter *gp)
@@ -3160,6 +3183,12 @@ static bool BridgeBuildResources(ID3D11Device *dev11, const DXGI_FORMAT *fmt,
     }
     dev1->Release();
     if (!ok) { BridgeReleaseTextures(); return false; }
+    return BridgeCreateViewFeature(fmt, gp);
+}
+
+static bool BridgeCreateViewFeature(const DXGI_FORMAT *fmt, const NVSDK_NGX_Parameter *gp)
+{
+    const UINT w = g_bridge.width, h = g_bridge.height;
     // The feature is created with the game's own render and output sizes, not
     // with the texture sizes: in an upscaling mode those are not the same thing.
     g_bridge.params->Set("Width", g_bridge.render_w);
@@ -3170,15 +3199,16 @@ static bool BridgeBuildResources(ID3D11Device *dev11, const DXGI_FORMAT *fmt,
     // for, and it was hardcoded to 2. That is Baldur's Gate 3's own answer
     // again -- the same mistake as the create flags, in the line above them.
     // Assetto Corsa and Gallipoli both ask for 1 and were given 2.
-    if (gp != nullptr) CopyUIntParam(gp, "PerfQualityValue", 2u);
-    else               g_bridge.params->Set("PerfQualityValue", 2);
+    unsigned int quality = 2;
+    BridgeCreateUInt(gp, "PerfQualityValue", &quality);
+    g_bridge.params->Set("PerfQualityValue", quality);
     {
         unsigned int q = 0, asked_q = 0;
         g_bridge.params->Get("PerfQualityValue", &q);
         static const char *kQ[] = { "MaxPerf", "Balanced", "MaxQuality",
                                     "UltraPerformance", "UltraQuality", "DLAA" };
         const bool have_q =
-            gp != nullptr && gp->Get("PerfQualityValue", &asked_q) == NGX_SUCCESS;
+            BridgeCreateUInt(gp, "PerfQualityValue", &asked_q);
         Log("[bridge] quality preset %u (%s), %s", q,
             q < _countof(kQ) ? kQ[q] : "unknown",
             have_q ? "copied from the game" : "the game set none, so 2 is used");
@@ -3201,7 +3231,9 @@ static bool BridgeBuildResources(ID3D11Device *dev11, const DXGI_FORMAT *fmt,
     const bool old_default = (g_cfg.flags == 107);
 
     FlagsFrom          flags_from = FLAGS_NONE;
-    const unsigned int resolved   = ResolveCreateFlags(gp, &flags_from);
+    unsigned int resolved = ResolveCreateFlags(gp, &flags_from);
+    if ((g_cfg.flags == -1 || old_default) && BridgeCreatedUInt("DLSS.Feature.Create.Flags", &resolved))
+        flags_from = FLAGS_GAME;
     const bool         copying    = (flags_from == FLAGS_GAME);
 
     g_bridge.params->Set("DLSS.Feature.Create.Flags", resolved);
@@ -3210,7 +3242,7 @@ static bool BridgeBuildResources(ID3D11Device *dev11, const DXGI_FORMAT *fmt,
         g_bridge.params->Get("DLSS.Feature.Create.Flags", &used);
         unsigned int asked = 0;
         const bool have_asked =
-            gp != nullptr && gp->Get("DLSS.Feature.Create.Flags", &asked) == NGX_SUCCESS;
+            BridgeCreateUInt(gp, "DLSS.Feature.Create.Flags", &asked);
 
         if (have_asked) LogCreateFlags("the game's create", asked);
         LogCreateFlags(kFlagsFromLabel[flags_from], used);
@@ -3258,11 +3290,9 @@ static bool BridgeBuildResources(ID3D11Device *dev11, const DXGI_FORMAT *fmt,
     // Mirror the game's own answer where it gave one. Deus Ex: Mankind Divided
     // asks for 0 here while BG3 asks for 1, and forcing either on the other is
     // inventing part of a contract that is meant to be copied.
-    if (gp != nullptr)
-        CopyUIntParam(gp, "DLSS.Enable.Output.Subrects",
-                      static_cast<unsigned int>(g_cfg.subrects));
-    else
-        g_bridge.params->Set("DLSS.Enable.Output.Subrects", g_cfg.subrects);
+    unsigned int output_subrects = static_cast<unsigned int>(g_cfg.subrects);
+    BridgeCreateUInt(gp, "DLSS.Enable.Output.Subrects", &output_subrects);
+    g_bridge.params->Set("DLSS.Enable.Output.Subrects", output_subrects);
     // The render preset picks which DLSS model weights run, and the D3D12 feature
     // was getting NGX's default while the game's own D3D11 feature ran whatever
     // it asked for -- so the two sides upscaled with different models and the
@@ -3287,9 +3317,9 @@ static bool BridgeBuildResources(ID3D11Device *dev11, const DXGI_FORMAT *fmt,
         for (const char *k : preset_keys)
         {
             unsigned int v = 0;
-            if (gp->Get(k, &v) != NGX_SUCCESS) continue;
+            const bool present = BridgeCreateUInt(gp, k, &v);
             g_bridge.params->Set(k, v);
-            if (!g_bridge.presets_reported)
+            if (present && !g_bridge.presets_reported)
                 Log("[bridge] %s = %u, copied from the game", k, v);
         }
         g_bridge.presets_reported = true;
@@ -4004,13 +4034,35 @@ static bool BridgeEnsureExposure(ID3D11Device *dev11, ID3D11Texture2D *src)
 // frame path; both under g_bridge_cs. Eight entries, oldest replaced: a game
 // holds one or two live handles and NGX reuses freed addresses, which is why a
 // create at a known address replaces its entry rather than adding one.
-struct BridgeCreateShape { const NVSDK_NGX_Handle *handle; unsigned int w, h, ow, oh; };
+static const char *kBridgeCreateKeys[] = {
+    "DLSS.Feature.Create.Flags", "PerfQualityValue", "DLSS.Enable.Output.Subrects",
+    "DLSS.Hint.Render.Preset.DLAA", "DLSS.Hint.Render.Preset.Quality",
+    "DLSS.Hint.Render.Preset.Balanced", "DLSS.Hint.Render.Preset.Performance",
+    "DLSS.Hint.Render.Preset.UltraPerformance", "DLSS.Hint.Render.Preset.UltraQuality",
+};
+struct BridgeCreateShape {
+    const NVSDK_NGX_Handle *handle;
+    unsigned int w, h, ow, oh;
+    unsigned int values[_countof(kBridgeCreateKeys)], present;
+};
 static BridgeCreateShape        g_create_shape[8];
 static int                      g_create_shape_next;
 static const NVSDK_NGX_Handle  *g_eval_handle;   // the evaluate being mirrored, set by its hook
 
+static bool BridgeCreatedUInt(const char *key, unsigned int *value)
+{
+    if (g_source != SRC_MIRROR || g_eval_handle == nullptr) return false;
+    for (const auto &shape : g_create_shape)
+        if (shape.handle == g_eval_handle)
+            for (unsigned i = 0; i < _countof(kBridgeCreateKeys); ++i)
+                if ((shape.present & (1u << i)) && strcmp(key, kBridgeCreateKeys[i]) == 0)
+                { *value = shape.values[i]; return true; }
+    return false;
+}
+
 static void BridgeNoteCreate(const NVSDK_NGX_Handle *handle, const NVSDK_NGX_Parameter *p)
 {
+    if (handle == nullptr) return;
     unsigned int w = 0, h = 0, ow = 0, oh = 0;
     if (p != nullptr)
     {
@@ -4029,7 +4081,6 @@ static void BridgeNoteCreate(const NVSDK_NGX_Handle *handle, const NVSDK_NGX_Par
                 "so the contract comes from the evaluate. Not a fault: not every engine "
                 "states it there.", w, h, ow, oh);
         }
-        return;
     }
     EnterCriticalSection(&g_bridge_cs);
     int slot = -1;
@@ -4037,6 +4088,10 @@ static void BridgeNoteCreate(const NVSDK_NGX_Handle *handle, const NVSDK_NGX_Par
         if (g_create_shape[i].handle == handle) slot = i;
     if (slot < 0) slot = g_create_shape_next++ % static_cast<int>(_countof(g_create_shape));
     g_create_shape[slot] = { handle, w, h, ow, oh };
+    if (p != nullptr)
+        for (unsigned i = 0; i < _countof(kBridgeCreateKeys); ++i)
+            if (p->Get(kBridgeCreateKeys[i], &g_create_shape[slot].values[i]) == NGX_SUCCESS)
+                g_create_shape[slot].present |= 1u << i;
     // The game replacing its feature invalidates the mirror's, whatever the
     // shape: the create flags can change with nothing else -- IsHDR when a game
     // switches its HDR on -- and until now only a size or format change
@@ -4063,6 +4118,8 @@ static bool BridgeCreateShapeOf(const NVSDK_NGX_Handle *handle, unsigned int *w,
     for (int i = 0; i < static_cast<int>(_countof(g_create_shape)); ++i)
         if (g_create_shape[i].handle == handle)
         {
+            if (!g_create_shape[i].w || !g_create_shape[i].h || !g_create_shape[i].ow || !g_create_shape[i].oh)
+                return false;
             *w = g_create_shape[i].w;   *h = g_create_shape[i].h;
             *ow = g_create_shape[i].ow; *oh = g_create_shape[i].oh;
             return true;
@@ -4103,6 +4160,47 @@ static void DumpSentParams()
         if (g_bridge.params->Get(kF[i], &v) == NGX_SUCCESS) Log("[bridge]     %-40s = %f", kF[i], v);
         else Log("[bridge]     %-40s   not set", kF[i]);
     }
+}
+
+// Under g_bridge_cs. Textures and queue stay shared; NGX's temporal state does not.
+static bool BridgeSelectHistory(const NVSDK_NGX_Parameter *gp)
+{
+    const auto *owner = g_source == SRC_MIRROR ? g_eval_handle : nullptr;
+    int free_slot = -1;
+    for (int i = 0; i < static_cast<int>(_countof(g_bridge.histories)); ++i)
+    {
+        const auto &history = g_bridge.histories[i];
+        if (history.feature != nullptr && history.game == owner)
+        {
+            g_bridge.feature = history.feature;
+            return true;
+        }
+        if (history.feature == nullptr && free_slot < 0) free_slot = i;
+    }
+    // ponytail: bounded like the create registry; additional views keep native DLSS.
+    // A future larger registry should retire histories on the game's ReleaseFeature.
+    if (free_slot < 0)
+    {
+        static bool reported = false;
+        if (!reported) { reported = true; Log("[bridge] all eight temporal histories are in use; additional game features keep their own DLSS."); }
+        return false;
+    }
+    // A resource build already created the first feature. Additional views need
+    // another feature only once, without reallocating the transport or resetting peers.
+    if (free_slot != 0)
+    {
+        g_bridge.feature = nullptr;
+        if (!BridgeCreateViewFeature(g_bridge.fmt, gp))
+        {
+            BridgeFail("view feature creation");
+            return false;
+        }
+    }
+    if (g_bridge.feature == nullptr) return false;
+    g_bridge.histories[free_slot] = { owner, g_bridge.feature };
+    Log("[bridge] temporal history: game=%p private=%p slot=%d",
+        static_cast<const void *>(owner), static_cast<void *>(g_bridge.feature), free_slot);
+    return true;
 }
 
 static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter *gp)
@@ -4525,6 +4623,13 @@ static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter
             dev11->Release();
             return;
         }
+    }
+
+    if (g_cfg.stage >= 3 && !BridgeSelectHistory(gp))
+    {
+        for (int i = 0; i < SLOT_COUNT; ++i) g[i]->Release();
+        dev11->Release();
+        return;
     }
 
     // If the game alternates its Color and Output textures, writing the result

--- a/src/dlss5-bridge.cpp
+++ b/src/dlss5-bridge.cpp
@@ -63,7 +63,7 @@
 #pragma comment(lib, "version.lib")
 
 // Kept in step with version.rc, which is where ReShade's overlay reads it from.
-#define BRIDGE_VERSION "1.4.13-pre5"
+#define BRIDGE_VERSION "1.4.13-pre6"
 
 extern "C" __declspec(dllexport) const char *NAME =
     "DLSS 5 Bridge " BRIDGE_VERSION;
@@ -2330,7 +2330,7 @@ static NVSDK_NGX_Result ForwardEvaluate(Hook &h, const char *tag, ID3D11DeviceCo
     }
 
     Breadcrumb("forwarding the game's DLSS evaluate");
-    const bool suppress = BridgeWillDeliver();
+    const bool suppress = BridgeWillDeliver(handle);
 
     NVSDK_NGX_Result r = NGX_SUCCESS;
     if (!suppress)

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // ReShade reads the add-on's version from here and shows it in its overlay, so
 // a bug report can name the exact build instead of describing it.
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,4,13,5
- PRODUCTVERSION 1,4,13,5
+ FILEVERSION    1,4,13,6
+ PRODUCTVERSION 1,4,13,6
  FILEOS         VOS_NT_WINDOWS32
  FILETYPE       VFT_DLL
 BEGIN
@@ -13,11 +13,11 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription",  "DLSS 5 Bridge"
-            VALUE "FileVersion",      "1.4.13-pre5"
+            VALUE "FileVersion",      "1.4.13-pre6"
             VALUE "InternalName",     "dlss5-bridge"
             VALUE "OriginalFilename", "dlss5-bridge.addon64"
             VALUE "ProductName",      "DLSS 5 Bridge"
-            VALUE "ProductVersion",   "1.4.13-pre5"
+            VALUE "ProductVersion",   "1.4.13-pre6"
         END
     END
     BLOCK "VarFileInfo"

--- a/tests/build-d3d11-histories-test.cmd
+++ b/tests/build-d3d11-histories-test.cmd
@@ -1,0 +1,28 @@
+@echo off
+setlocal
+rem CPU-only production D3D11 history test. --build-only skips execution.
+if defined VCVARS goto toolchain_found
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+  echo test: Visual Studio Installer vswhere.exe was not found; set VCVARS to vcvars64.bat
+  exit /b 1
+)
+for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "VCVARS=%%I\VC\Auxiliary\Build\vcvars64.bat"
+:toolchain_found
+if not exist "%VCVARS%" (
+  echo test: no vcvars64.bat at "%VCVARS%"
+  exit /b 1
+)
+call "%VCVARS%" >nul 2>&1
+if errorlevel 1 exit /b 1
+cd /d "%~dp0"
+if not exist build mkdir build
+if errorlevel 1 exit /b 1
+cl /nologo /W4 /O2 /MT /EHsc /std:c++17 /I..\src\reshade ^
+   /Fo:build\ /Fe:build\d3d11-histories.exe d3d11-histories.cpp ^
+   /link user32.lib advapi32.lib bcrypt.lib
+if errorlevel 1 exit /b 1
+if /i "%~1"=="--build-only" exit /b 0
+cd build
+d3d11-histories.exe
+exit /b %ERRORLEVEL%

--- a/tests/d3d11-histories.cpp
+++ b/tests/d3d11-histories.cpp
@@ -1,0 +1,87 @@
+// Production history selection/ownership without a GPU. Real feature creation
+// and atlas copy-back are exercised by ngxGym's split-history scenario.
+#include "../src/dlss5-bridge.cpp"
+#define EXPECT(c) do { if (!(c)) { printf("FAIL line %d: %s\n", __LINE__, #c); return 1; } } while (0)
+
+static NVSDK_NGX_Handle *released[32];
+static unsigned releases;
+static NVSDK_NGX_Result RecordRelease(NVSDK_NGX_Handle *feature)
+{ released[releases++] = feature; return NGX_SUCCESS; }
+
+int main()
+{
+    InitializeCriticalSection(&g_log_cs);
+    InitializeCriticalSection(&g_bridge_cs);
+    strcpy_s(g_log_path, "NUL");
+    g_source = SRC_MIRROR;
+    NVSDK_NGX_Handle game[9] = {}, private_feature[9] = {};
+    g_bridge.release_feature = RecordRelease;
+    g_bridge.feature = &private_feature[0];
+    g_eval_handle = &game[0];
+    EXPECT(BridgeSelectHistory(nullptr));
+    EXPECT(g_bridge.histories[0].game == &game[0]);
+    EXPECT(g_bridge.histories[0].feature == &private_feature[0]);
+    g_bridge.histories[1] = { &game[1], &private_feature[1] };
+    g_bridge.frame_ready = g_bridge.session_ready = true;
+    g_bridge.frames_done = 1;
+    g_bridge.need_reset = false;
+    for (unsigned i = 0; i < 100; ++i)
+    {
+        g_eval_handle = &game[i % 2];
+        EXPECT(BridgeSelectHistory(nullptr));
+        EXPECT(g_bridge.feature == &private_feature[i % 2]);
+        EXPECT(!g_bridge.need_reset);
+        EXPECT(BridgeWillDeliver(g_eval_handle));
+    }
+    EXPECT(!BridgeWillDeliver(&game[2]));
+    BridgeReleaseTextures();
+    EXPECT(releases == 2 && released[0] != released[1]);
+    EXPECT(g_bridge.feature == nullptr && !g_bridge.frame_ready);
+    BridgeReleaseTextures();
+    EXPECT(releases == 2);
+    puts("PASS: independent selection, no peer reset, suppression and unique release");
+
+    g_bridge.histories[0] = { &game[0], &private_feature[0] };
+    g_bridge.feature = &private_feature[2]; // A create failure before registration.
+    BridgeReleaseTextures();
+    EXPECT(releases == 4 && released[2] == &private_feature[0] && released[3] == &private_feature[2]);
+    for (unsigned i = 0; i < 8; ++i) g_bridge.histories[i] = { &game[i], &private_feature[i] };
+    g_bridge.feature = &private_feature[0];
+    g_eval_handle = &game[8];
+    EXPECT(!BridgeSelectHistory(nullptr));
+    EXPECT(g_bridge.feature == &private_feature[0] && !BridgeWillDeliver(&game[8]));
+    BridgeReleaseTextures();
+    EXPECT(releases == 12);
+    puts("PASS: partial creation cleanup and bounded native fallback");
+
+    SynthParams params;
+    params.Set("Width", 640u); params.Set("Height", 360u);
+    params.Set("OutWidth", 1280u); params.Set("OutHeight", 720u);
+    params.Set("DLSS.Feature.Create.Flags", 15u);
+    params.Set("PerfQualityValue", 2u);
+    params.Set("DLSS.Hint.Render.Preset.Quality", 3u);
+    BridgeNoteCreate(&game[0], &params);
+    params.Set("DLSS.Feature.Create.Flags", 7u);
+    params.Set("PerfQualityValue", 0u);
+    BridgeNoteCreate(&game[1], &params);
+    g_eval_handle = &game[0];
+    unsigned value = 0;
+    EXPECT(BridgeCreateUInt(&params, "DLSS.Feature.Create.Flags", &value) && value == 15);
+    EXPECT(BridgeCreateUInt(&params, "PerfQualityValue", &value) && value == 2);
+    g_eval_handle = &game[1];
+    EXPECT(BridgeCreateUInt(&params, "DLSS.Feature.Create.Flags", &value) && value == 7);
+    EXPECT(BridgeCreateUInt(&params, "PerfQualityValue", &value) && value == 0);
+    g_bridge.frame_ready = true;
+    params.Reset(); // NGX reused an address, with no complete create shape.
+    BridgeNoteCreate(&game[1], &params);
+    EXPECT(!g_bridge.frame_ready && g_bridge.need_reset);
+    unsigned w, h, ow, oh;
+    EXPECT(!BridgeCreateShapeOf(&game[1], &w, &h, &ow, &oh));
+    EXPECT(!BridgeCreatedUInt("DLSS.Feature.Create.Flags", &value));
+    g_eval_handle = &game[0];
+    EXPECT(BridgeCreatedUInt("DLSS.Feature.Create.Flags", &value) && value == 15);
+    g_source = SRC_SYNTH;
+    EXPECT(!BridgeCreatedUInt("DLSS.Feature.Create.Flags", &value));
+    puts("PASS: shared parameter block, per-create options, handle reuse and synthetic isolation");
+    return 0;
+}


### PR DESCRIPTION
D3D11 games with two same-sized DLSS features could feed both views into one private DLSS history. Give each game feature its own private history while reusing the ordered texture transport. Preserve recorded creation options per game handle, clear histories on resource recreation, and leave additional views on native DLSS if the bounded registry is full.

Validation: the background Gym reproduces two game features sharing one private feature on the official pre5 artifact. The candidate creates distinct histories, preserves the untouched atlas half, resets each view on its first frame, and returns to single-view rendering. Runs passed with and without the neural addon; the neural log confirms feature-18 creation and successful evaluation. CPU ownership/lifetime/handle-reuse tests, D3D11 WARP pixel tests, and Vulkan FG routing tests pass. Local D3D11 debug-layer validation was unavailable.

This is a reproduced Bridge defect relevant to #12, not confirmation that every BG3 split-screen artifact is fixed. No game was launched and no performance benchmark was run. Prepare version 1.4.13-pre6 for reporter testing; stable remains unchanged.
