### PR TITLE
Avoid rebuilding shared textures for unequal split-screen views

### DIFF
--- a/src/bridge.h
+++ b/src/bridge.h
@@ -239,7 +239,10 @@ struct Bridge
     NVSDK_NGX_Handle    *feature;
     // One temporal history per game feature, sharing the ordered transport.
     // Invalidated together when the resource shape or create contract changes.
-    struct History { const NVSDK_NGX_Handle *game; NVSDK_NGX_Handle *feature; };
+    struct History {
+        const NVSDK_NGX_Handle *game; NVSDK_NGX_Handle *feature;
+        unsigned int w, h, ow, oh;
+    };
     History histories[8];
 
     // The exposure texture is kept apart from the slot array rather than made a

--- a/src/bridge.inc
+++ b/src/bridge.inc
@@ -4197,7 +4197,8 @@ static bool BridgeSelectHistory(const NVSDK_NGX_Parameter *gp)
         }
     }
     if (g_bridge.feature == nullptr) return false;
-    g_bridge.histories[free_slot] = { owner, g_bridge.feature };
+    g_bridge.histories[free_slot] = { owner, g_bridge.feature,
+        g_bridge.render_w, g_bridge.render_h, g_bridge.ngx_out_w, g_bridge.ngx_out_h };
     Log("[bridge] temporal history: game=%p private=%p slot=%d",
         static_cast<const void *>(owner), static_cast<void *>(g_bridge.feature), free_slot);
     return true;
@@ -4547,8 +4548,16 @@ static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter
             gow, goh, d[SLOT_OUTPUT].Width, d[SLOT_OUTPUT].Height, output_x, output_y);
     }
 
-    bool shape_changed = (gw != g_bridge.render_w)  || (gh != g_bridge.render_h) ||
-                         (gow != g_bridge.ngx_out_w) || (goh != g_bridge.ngx_out_h);
+    // Feature dimensions belong to a view, not to the shared allocation. Two
+    // views can use different subrect heights in the same atlas (BG3 dialogs).
+    // Rebuild for a changed contract of the SAME view, never just for switching
+    // between two already valid contracts. New views get their feature below.
+    bool shape_changed = false;
+    const auto *owner = g_source == SRC_MIRROR ? g_eval_handle : nullptr;
+    for (const auto &history : g_bridge.histories)
+        if (history.feature != nullptr && history.game == owner)
+            shape_changed = history.w != gw || history.h != gh ||
+                            history.ow != gow || history.oh != goh;
     // Every slot's own size, not only Color's and Output's. Depth or motion
     // vectors changing size on their own used to move nothing here.
     for (int i = 0; i < SLOT_COUNT && !shape_changed; ++i)
@@ -4624,6 +4633,9 @@ static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter
             return;
         }
     }
+
+    g_bridge.render_w = gw; g_bridge.render_h = gh;
+    g_bridge.ngx_out_w = gow; g_bridge.ngx_out_h = goh;
 
     if (g_cfg.stage >= 3 && !BridgeSelectHistory(gp))
     {
@@ -4745,6 +4757,12 @@ static void BridgeFrameInner(ID3D11DeviceContext *ctx, const NVSDK_NGX_Parameter
     g_bridge.params->Set("MotionVectors", g_bridge.tex12[SLOT_MV]);
     if (g_bridge.exp12 != nullptr)
         g_bridge.params->Set("ExposureTexture", g_bridge.exp12);
+    // The parameter block is shared too; consumers must see this view's
+    // contract rather than whichever view was created last.
+    g_bridge.params->Set("Width", g_bridge.render_w);
+    g_bridge.params->Set("Height", g_bridge.render_h);
+    g_bridge.params->Set("OutWidth", g_bridge.ngx_out_w);
+    g_bridge.params->Set("OutHeight", g_bridge.ngx_out_h);
     // Mirror the game's own subrect description rather than inventing one. In an
     // upscaling preset the rendered area is a corner of a larger texture, and
     // guessing it is what made DLSS Quality produce a soft, effect-free image.

--- a/src/dlss5-bridge.cpp
+++ b/src/dlss5-bridge.cpp
@@ -63,7 +63,7 @@
 #pragma comment(lib, "version.lib")
 
 // Kept in step with version.rc, which is where ReShade's overlay reads it from.
-#define BRIDGE_VERSION "1.4.13-pre6"
+#define BRIDGE_VERSION "1.4.13-pre7"
 
 extern "C" __declspec(dllexport) const char *NAME =
     "DLSS 5 Bridge " BRIDGE_VERSION;

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // ReShade reads the add-on's version from here and shows it in its overlay, so
 // a bug report can name the exact build instead of describing it.
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION    1,4,13,6
- PRODUCTVERSION 1,4,13,6
+ FILEVERSION    1,4,13,7
+ PRODUCTVERSION 1,4,13,7
  FILEOS         VOS_NT_WINDOWS32
  FILETYPE       VFT_DLL
 BEGIN
@@ -13,11 +13,11 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "FileDescription",  "DLSS 5 Bridge"
-            VALUE "FileVersion",      "1.4.13-pre6"
+            VALUE "FileVersion",      "1.4.13-pre7"
             VALUE "InternalName",     "dlss5-bridge"
             VALUE "OriginalFilename", "dlss5-bridge.addon64"
             VALUE "ProductName",      "DLSS 5 Bridge"
-            VALUE "ProductVersion",   "1.4.13-pre6"
+            VALUE "ProductVersion",   "1.4.13-pre7"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
BG3 split-screen can alternate 891x1002 -> 1536x1728 and 891x852 -> 1536x1469 views inside the same shared texture allocations. Pre6 treats every switch as a resource resize, repeatedly rebuilds the transport, and eventually stops with "the render shape never settles".

Keep the render/output dimensions with each private history. Switching between distinct views reuses the allocation and selects each view's feature; a changed contract for the same view or changed allocation still rebuilds. Restore the current view's dimensions in the shared evaluation parameter block for consumers. Prepare pre7 for reporter testing.

Validation: the new unequal-height Gym stimulus fails the bounded-feature-count assertion with the official pre6 artifact and passes with this change, including 120 alternating evaluations, untouched atlas halves and return to a single view. Neural rendering is active and evaluation succeeds. Existing CPU history tests, Vulkan FG routing tests and D3D11 WARP pixels pass; local debug-layer validation remains unavailable. No games or performance benchmarks run.

Related to #12. This addresses the reproduced rebuild/stutter/stand-down problem; it does not claim that BG3's second-view neural output is fixed.
